### PR TITLE
Performance upgrade

### DIFF
--- a/src/BackTest/hedging.jl
+++ b/src/BackTest/hedging.jl
@@ -6,13 +6,13 @@ using Distributions
         pricing_model,
         strategy_type,
         future_prices,
-        n_timesteps::Int,
-        timesteps_per_period::Int,
-        cash_injection::Real= 0,
-        fin_obj_count::Real= 0,
-        widget_count::Real= 0,
-        pay_int_rate::Real= 0,
-        hold_return_int_rate::Real= 0;
+        n_timesteps,
+        timesteps_per_period,
+        cash_injection = 0.0,
+        fin_obj_count = 0.0,
+        widget_count = 0.0,
+        pay_int_rate = 0.0,
+        hold_return_int_rate = 0.0;
         kwargs...
     )
 
@@ -24,7 +24,7 @@ Returns the dollar cumulative return from the strategy, the time-series of all h
 the strategy, and the updated object array. 
 
 ## Arguments
-- `obj::FinancialInstrument`: financial instrument the trading or hedging strategy runs on
+- `obj`: financial instrument the trading or hedging strategy runs on
 - `pricing_model`: `Model` subtype that defines how to price the `obj`
 - `strategy_type`: `Hedging` subtype that the `strategy()` function dispatches off. Must provide a new subtype for new `strategy()` methods
 - `future_prices`: vector of future prices for the underlying `Widget` asset of obj to run strategy on
@@ -60,7 +60,7 @@ cumulative_return, ts_holdings, obj = strategy_returns(
     future_prices,
     10,
     252, 
-    10, 
+    10.0, 
     fin_obj_count, 
     widget_count,
     pay_int_rate, 
@@ -164,14 +164,14 @@ end
         objs::Vector{<:FinancialInstrument},
         pricing_model,
         strategy_type,
-        future_prices::Dict{String, Vector{Real}},
-        n_timesteps::Int,
-        timesteps_per_period::Int,
-        cash_injection::Real = 0,
-        fin_obj_count::Dict{String, Real},
-        widget_count::Dict{String, Real},
-        pay_int_rate::Real= 0,
-        hold_return_int_rate::Real= 0;
+        future_prices,
+        n_timesteps,
+        timesteps_per_period,
+        cash_injection = 0.0,
+        fin_obj_count,
+        widget_count,
+        pay_int_rate = 0.0,
+        hold_return_int_rate = 0.0;
         kwargs...
     )
 
@@ -219,7 +219,7 @@ future_prices = Dict(
 # make dictionaries for the starting amounts held of each Widget and FinancialInstrument
 fin_obj_count = Dict("call" => 1.0, "call2" => 2)
 widget_count = Dict("stock" => 2.0, "stock2" => 3)
-cash_injection = 0
+cash_injection = 0.0
 
 pay_int_rate = 0.08
 hold_return_int_rate = 0.02
@@ -419,18 +419,18 @@ end
 """
     buy(
         fin_obj::FinancialInstrument, 
-        number::Real, 
+        number,
         holdings, 
         pricing_model, 
-        trasaction_cost::Real; 
+        trasaction_cost;
         kwargs...
     )
     buy(
         fin_obj::Widget, 
-        number::Real, 
+        number,
         holdings, 
         pricing_model, 
-        trasaction_cost::Real; 
+        trasaction_cost;
         kwargs...
     )
 
@@ -492,18 +492,18 @@ end
 """
     sell(
         fin_obj::FinancialInstrument, 
-        number::Real, 
+        number,
         holdings, 
         pricing_model, 
-        trasaction_cost::Real; 
+        trasaction_cost;
         kwargs...
     )
     sell(
         fin_obj::Widget, 
-        number::Real,
+        number,
         holdings, 
         pricing_model, 
-        trasaction_cost::Real; 
+        trasaction_cost;
         kwargs...
     )
 
@@ -515,7 +515,7 @@ pricing_model. To be used in `strategy()` functions to define trading and hedgin
 - `number`: number of objects to be sold
 - `holdings`: dictionary with all holdings of widgets and financial instruments (generally supplied by strategy_returns() function)
 - `pricing_model`: Model subtype to be used to define sell price
-- `transaction_cost::Real`: total transaction costs for the transaction
+- `transaction_cost`: total transaction costs for the transaction
 - `kwargs`: pass through for any keyword arguments needed by the `pricing_model` in `price!()` function
 """
 function sell(

--- a/src/BackTest/hedging.jl
+++ b/src/BackTest/hedging.jl
@@ -442,7 +442,7 @@ pricing_model. To be used in `strategy()` functions to define trading and hedgin
 - `number`: number of objects to be bought
 - `holdings`: dictionary with all holdings of widgets and financial instruments (generally supplied by strategy_returns() function)
 - `pricing_model`: Model subtype to be used to define buy price
-- `transaction_cost::Real`: total transaction costs for the transaction
+- `transaction_cost`: total transaction costs for the transaction
 - `kwargs`: pass through for any keyword arguments needed by the `pricing_model` in `price!()` function
 """
 function buy(

--- a/src/BackTest/hedging.jl
+++ b/src/BackTest/hedging.jl
@@ -74,13 +74,13 @@ function strategy_returns(
     pricing_model,
     strategy_type,
     future_prices,
-    n_timesteps::Int,
-    timesteps_per_period::Int,
-    cash_injection::AbstractFloat = 0,
-    fin_obj_count::AbstractFloat = 0,
-    widget_count::AbstractFloat = 0,
-    pay_int_rate::AbstractFloat = 0,
-    hold_return_int_rate::AbstractFloat = 0;
+    n_timesteps,
+    timesteps_per_period,
+    cash_injection = 0.0,
+    fin_obj_count = 0.0,
+    widget_count = 0.0,
+    pay_int_rate = 0.0,
+    hold_return_int_rate = 0.0;
     kwargs...
 ) 
     # make some checks
@@ -156,44 +156,6 @@ function strategy_returns(
     end
 
     return holdings["cash"] - initial_value, ts_holdings, obj
-end
-
-# converter function to let users input whatever type of number they want
-function strategy_returns(
-    obj::FinancialInstrument,
-    pricing_model,
-    strategy_type,
-    future_prices,
-    n_timesteps::Int,
-    timesteps_per_period::Int,
-    cash_injection::Real = 0,
-    fin_obj_count::Real = 0,
-    widget_count::Real = 0,
-    pay_int_rate::Real = 0,
-    hold_return_int_rate::Real = 0;
-    kwargs...
-)  
-
-    cash_injection = convert(AbstractFloat, cash_injection)
-    fin_obj_count = convert(AbstractFloat,fin_obj_count)
-    widget_count= convert(AbstractFloat, widget_count)
-    pay_int_rate = convert(AbstractFloat, pay_int_rate)
-    hold_return_int_rate= convert(AbstractFloat, hold_return_int_rate)
-
-    strategy_returns(
-        obj,
-        pricing_model,
-        strategy_type,
-        future_prices,
-        n_timesteps,
-        timesteps_per_period,
-        cash_injection,
-        fin_obj_count,
-        widget_count,
-        pay_int_rate,
-        hold_return_int_rate;
-        kwargs...
-    )  
 end
 
 # for an array of fin objs
@@ -281,16 +243,16 @@ function strategy_returns(
     objs::Vector{<:FinancialInstrument},
     pricing_model,
     strategy_type,
-    future_prices::Dict{String,Vector{AbstractFloat}},
-    n_timesteps::Int,
-    timesteps_per_period::Int,
-    cash_injection::AbstractFloat = 0.0,
-    fin_obj_count = Dict{String,AbstractFloat}(),
-    widget_count = Dict{String,AbstractFloat}(),
-    pay_int_rate::AbstractFloat = 0,
-    hold_return_int_rate::AbstractFloat = 0;
+    future_prices,
+    n_timesteps,
+    timesteps_per_period,
+    cash_injection = 0.0,
+    fin_obj_count = Dict{String,Float64}(),
+    widget_count = Dict{String,Float64}(),
+    pay_int_rate = 0.0,
+    hold_return_int_rate = 0.0;
     kwargs...
-) where {T<:Real}
+)
 
     # checks before the sim starts
     for fin_obj in objs
@@ -332,12 +294,12 @@ function strategy_returns(
 
 
     # set up holdings dictionary. Holdings is the active holdings of the program while ts_holdings produces a history
-   holdings = Dict{String, AbstractFloat}(
+   holdings = Dict(
         "cash" => cash_injection, 
         fin_obj_count..., 
         widget_count...
     ) 
-    ts_holdings = Dict("cash" => AbstractFloat[cash_injection])
+    ts_holdings = Dict("cash" => [cash_injection])
 
     for key in keys(widget_dict)
         try
@@ -418,48 +380,8 @@ function strategy_returns(
     return holdings["cash"] - initial_value, ts_holdings, obj_array, widget_dict
 end
 
-# function to convert all to float so can input whatever numeric type
-function strategy_returns(
-    objs::Vector{<:FinancialInstrument},
-    pricing_model,
-    strategy_type,
-    future_prices::Dict{String,Vector{T}},
-    n_timesteps::Int,
-    timesteps_per_period::Int,
-    cash_injection::Real = 0.0,
-    fin_obj_count::Dict{String, Real} = Dict{String, AbstractFloat}(),
-    widget_count::Dict{String, Real} = Dict{String, AbstractFloat}(),
-    pay_int_rate::Real = 0,
-    hold_return_int_rate::Real = 0;
-    kwargs...
-) where {T<:Real}
-
-    cash_injection = convert(AbstractFloat, cash_injection)
-    future_prices = convert(Dict{String, Vector{AbstractFloat}}, future_prices)
-    fin_obj_count = convert(Dict{String, AbstractFloat}, fin_obj_count)
-    widget_count = convert(Dict{String, AbstractFloat}, widget_count)
-    pay_int_rate = convert(AbstractFloat, pay_int_rate)
-    hold_return_int_rate = convert(AbstractFloat, hold_return_int_rate)
-
-    strategy_returns(
-        objs,
-        pricing_model,
-        strategy_type,
-        future_prices,
-        n_timesteps,
-        timesteps_per_period,
-        cash_injection,
-        fin_obj_count,
-        widget_count,
-        pay_int_rate,
-        hold_return_int_rate;
-        kwargs...
-    )
-end
-
 # helper for copying an array of financial objects. Keeps pointer structure the same
-
-function copy_obj(objs::Vector{<:FinancialInstrument})
+function copy_obj(objs)
     widget_dict = Dict{String, Widget}()
     new_obj_arr = []
     # do first one
@@ -525,10 +447,10 @@ pricing_model. To be used in `strategy()` functions to define trading and hedgin
 """
 function buy(
     fin_obj::FinancialInstrument,
-    number::Real,
+    number,
     holdings,
     pricing_model,
-    transaction_cost::Real = 0.0;
+    transaction_cost = 0.0;
     kwargs...
 )
     # checks for non sensical buying
@@ -551,10 +473,10 @@ end
 
 function buy(
     widget_obj::Widget, 
-    number::Real, 
+    number,
     holdings, 
     pricing_model, 
-    transaction_cost::Real=0.0,
+    transaction_cost = 0.0;
     kwargs...
 )
     if number < 0
@@ -598,10 +520,10 @@ pricing_model. To be used in `strategy()` functions to define trading and hedgin
 """
 function sell(
     fin_obj::FinancialInstrument,
-    number::Real,
+    number,
     holdings,
     pricing_model,
-    transaction_cost::Real = 0.0;
+    transaction_cost = 0.0;
     kwargs...
 )
     if number < 0
@@ -622,10 +544,10 @@ end
 
 function sell(
     widget_obj::Widget, 
-    number::Real, 
+    number,
     holdings, 
     pricing_model, 
-    transaction_cost::Real = 0.0;
+    transaction_cost = 0.0;
     kwargs...
 )
     
@@ -668,7 +590,7 @@ end
 
 function unwind(
     obj_array::Vector{<:FinancialInstrument},
-    widget_dict::Dict{String, <:Widget},
+    widget_dict,
     pricing_model,
     holdings
 )
@@ -703,7 +625,7 @@ end
 # default update_function for all financial instruments and all pricing/ strategy modes
 function update_obj(
     obj::FinancialInstrument,
-    strategy_type::Type{<:Hedging},
+    strategy_type,
     pricing_model,
     holdings,
     future_prices,
@@ -749,7 +671,7 @@ end
 
 function update_obj(
     obj::Widget, 
-    strategy_type::Type{<:Hedging}, 
+    strategy_type, 
     pricing_model, 
     holdings, 
     future_prices, 
@@ -774,8 +696,8 @@ end
 # for multi strategy_returns()
 # general update_obj function that will always fall back onto for multi strategy_returns()
 function update_obj(
-    obj_array::Vector{T},
-    widget_dict::Dict{String, <:Widget},
+    obj_array::Vector{<:FinancialInstrument},
+    widget_dict,
     strategy_type,
     pricing_model,
     holdings,
@@ -783,7 +705,7 @@ function update_obj(
     n_timesteps,
     timesteps_per_period,
     step
-) where {T<:FinancialInstrument}
+)
 
     # update all the widgets first
     for (name, widget) in widget_dict

--- a/src/DataGeneration/DataGeneration.jl
+++ b/src/DataGeneration/DataGeneration.jl
@@ -29,7 +29,7 @@ Possible DataGenInput types are
 - `Input<:DataGenInput`:  struct with parameters to generate data
 - `nSimulation::Integer`: the number of simulations to run.  
 ## Outputs
-- `data::AbstractArray`: nTimeStep x nSimulation Real valued array, where each column
+- `data`:   nTimeStep x nSimulation array, where each column
                          contains the data for one simulation, and each row contains
                          data for each timestep
 

--- a/src/DataGeneration/DataGeneration.jl
+++ b/src/DataGeneration/DataGeneration.jl
@@ -27,7 +27,7 @@ Possible DataGenInput types are
 
 ## Arguments
 - `Input<:DataGenInput`:  struct with parameters to generate data
-- `nSimulation::Integer`: the number of simulations to run.  
+- `nSimulation`: the number of simulations to run.  
 ## Outputs
 - `data`:   nTimeStep x nSimulation array, where each column
                          contains the data for one simulation, and each row contains
@@ -46,7 +46,7 @@ input2 = BootstrapInput(data1, Stationary; n=100);
 data2 = makedata(input2, 2)
 ```
 """
-makedata(input::Any) = error("Use a DataGenInput subtype to synthesize data")
+makedata(input) = error("Use a DataGenInput subtype to synthesize data")
 
 include("logdiffusion.jl")
 include("bootstrap.jl")

--- a/src/DataGeneration/bootstrap.jl
+++ b/src/DataGeneration/bootstrap.jl
@@ -13,10 +13,10 @@ Contains the parameters needed to perform block bootstrap of type T to be used b
 function. T can be any subtype of TSBootMethod: Stationary, MovingBlock, or CircularBlock.
 
 ## Keyword Arguments
-- `input_data::Array{<:Real}`: data to be resampled. Must be a 1-D array
+- `input_data`: data to be resampled. Must be a 1-D array
 - `bootstrap_method`: Type of time series bootstrap to use. Must be subtype of TSBootMethod.
-- `n::Int64`: size of resampled output data. Default: 100
-- `block_size::Float64`: block size to use. Defaults to the optimal block length using `opt_block_length()`
+- `n`: size of resampled output data. Default: 100
+- `block_size`: block size to use. Defaults to the optimal block length using `opt_block_length()`
 
 ## Examples
 ```julia

--- a/src/DataGeneration/bootstrap.jl
+++ b/src/DataGeneration/bootstrap.jl
@@ -15,8 +15,8 @@ function. T can be any subtype of TSBootMethod: Stationary, MovingBlock, or Circ
 ## Keyword Arguments
 - `input_data::Array{<:Real}`: data to be resampled. Must be a 1-D array
 - `bootstrap_method`: Type of time series bootstrap to use. Must be subtype of TSBootMethod.
-- `n::Integer`: size of resampled output data. Default: 100
-- `block_size::Integer`: block size to use. Defaults to the optimal block length using `opt_block_length()`
+- `n::Int64`: size of resampled output data. Default: 100
+- `block_size::Float64`: block size to use. Defaults to the optimal block length using `opt_block_length()`
 
 ## Examples
 ```julia
@@ -30,8 +30,8 @@ input2 = BootstrapInput{MovingBlock}(;kwargs...)
 """
 struct BootstrapInput{T<:TSBootMethod} <: DataGenInput
     input_data::Array{<:Real} # array of data to be resampled
-    n::Integer # desired size of resampled data
-    block_size::Float32 #desired average block size (will add more to this later)
+    n::Int64 # desired size of resampled data
+    block_size::Float64 #desired average block size (will add more to this later)
 
     # constructor for kwargs
     function BootstrapInput{T}(;

--- a/src/DataGeneration/bootstrap.jl
+++ b/src/DataGeneration/bootstrap.jl
@@ -81,7 +81,7 @@ function BootstrapInput(
     return BootstrapInput{bootstrap_method,TI,TF,TR}(input_data, n, block_size)
 end
 
-function makedata(param::BootstrapInput{Stationary}, nSimulation::Integer = 1)
+function makedata(param::BootstrapInput{Stationary}, nSimulation = 1)
     # check for block_size > 1 so geometric distro doesn't blow up
     param.block_size > 1 ? block_size = param.block_size : block_size = 1.01
     p = 1 / block_size
@@ -120,7 +120,7 @@ function makedata(param::BootstrapInput{Stationary}, nSimulation::Integer = 1)
     return data
 end
 
-function makedata(param::BootstrapInput{MovingBlock}, nSimulation::Integer = 1)
+function makedata(param::BootstrapInput{MovingBlock}, nSimulation = 1)
     data = zeros((param.n, nSimulation))
     for run_num = 1:nSimulation
         block_counter = 0
@@ -140,7 +140,7 @@ function makedata(param::BootstrapInput{MovingBlock}, nSimulation::Integer = 1)
     return data
 end
 
-function makedata(param::BootstrapInput{CircularBlock}, nSimulation::Integer = 1)
+function makedata(param::BootstrapInput{CircularBlock}, nSimulation = 1)
     data = zeros((param.n, nSimulation))
     for run_num = 1:nSimulation
         block_counter = 0
@@ -203,7 +203,7 @@ st_bl = opt_block_length(ar1, Stationary)
 cb_bl = opt_block_length(ar1, CircularBlock)
 ```
 """
-function opt_block_length(array, bootstrap_method::Type{<:TSBootMethod})
+function opt_block_length(array, bootstrap_method)
     N = size(array)[1]
     K_N = max(5, floor(Int, sqrt(log10(N))))
     # m_max from Kevin Sheppard arch package and Andrew Patton Matlab code

--- a/src/DataGeneration/factory.jl
+++ b/src/DataGeneration/factory.jl
@@ -7,8 +7,8 @@ All widgets use first difference.
 
 ## Positional Inputs
 - `widget::Widget`: A concrete widget struct. See the Widget documentation for more.
-- `bootstrap_method::TSBootMethod`: A subtype of TSBootMethod: Stationary, MovingBlock, or CircularBlock.
-- `nWidgets::Signed`: The amount of widgets you want widget factory to return.
+- `bootstrap_method`: A subtype of TSBootMethod: Stationary, MovingBlock, or CircularBlock.
+- `nWidgets`: The amount of widgets you want widget factory to return.
 
 
 # Example

--- a/src/DataGeneration/factory.jl
+++ b/src/DataGeneration/factory.jl
@@ -19,7 +19,7 @@ widget = Stock(prices)
 list_of_widgets = factory(widget, Stationary, 2)
 ```
 """
-function factory(widget::Widget, bootstrap_method::Type{<:TSBootMethod}, nWidgets::Signed)
+function factory(widget::Widget, bootstrap_method, nWidgets)
     fields = field_exclude(widget)
     # calculating the returns
     # TODO: check if time series Stationary 
@@ -52,8 +52,8 @@ end
 
 function factory(
     fin_instrument::FinancialInstrument,
-    bootstrap_method::Type{<:TSBootMethod},
-    nInstruments::Signed,
+    bootstrap_method,
+    nInstruments,
 )
     fields = field_exclude(fin_instrument)
     widget_ar = factory(fin_instrument.widget, bootstrap_method, nInstruments)

--- a/src/DataGeneration/logdiffusion.jl
+++ b/src/DataGeneration/logdiffusion.jl
@@ -22,10 +22,10 @@ then shifted and scaled by the drift and volatility terms.
 
 ## Arguments
 
-- `nTimeStep::Integer`:  The number of time steps to synthesize.
-- `initial::Real`:  The assumed value at the 0th time step. Default: 100.
-- `volatility::Real`:  The price volatility as a standard deviation in terms of implied time period. Defaults to 0.3.
-- `drift::Real`: The drift parameter describes the mean of the log-normal diffusion process 
+- `nTimeStep::Int64`:  The number of time steps to synthesize.
+- `initial::Float64`:  The assumed value at the 0th time step. Default: 100.
+- `volatility::Float64`:  The price volatility as a standard deviation in terms of implied time period. Defaults to 0.3.
+- `drift::Float64`: The drift parameter describes the mean of the log-normal diffusion process 
 given in terms of the entire implied time period (if simulating a year, drift would be annual 
 expected return). Defaults to 0.02.
 
@@ -42,10 +42,10 @@ input3 = LogDiffInput(;kwargs...)
 ```
 """
 struct LogDiffInput <: DataGenInput
-    nTimeStep::Integer # number of timesteps to simulate
-    initial::Real # in dollars
-    volatility::Real # volatility as a standard deviation
-    drift::Real # 
+    nTimeStep::Int64 # number of timesteps to simulate
+    initial::Float64 # in dollars
+    volatility::Float64 # volatility as a standard deviation
+    drift::Float64 # 
     # constructor for kwargs
     function LogDiffInput(;
         nTimeStep,

--- a/src/DataGeneration/logdiffusion.jl
+++ b/src/DataGeneration/logdiffusion.jl
@@ -41,35 +41,39 @@ kwargs = Dict(:nTimeStep=>250, :initial=>100, :volatility=>.05, :drift=>.1)
 input3 = LogDiffInput(;kwargs...)
 ```
 """
-struct LogDiffInput <: DataGenInput
-    nTimeStep::Int64 # number of timesteps to simulate
-    initial::Float64 # in dollars
-    volatility::Float64 # volatility as a standard deviation
-    drift::Float64 # 
+struct LogDiffInput{TI,TR} <: DataGenInput
+    nTimeStep::TI # number of timesteps to simulate
+    initial::TR # in dollars
+    volatility::TR # volatility as a standard deviation
+    drift::TR # 
     # constructor for kwargs
-    function LogDiffInput(;
+    function LogDiffInput{TI,TR}(;
         nTimeStep,
         initial = 100,
         volatility = 0.3,
         drift = 0.02,
-    )
+    ) where {TI,TR}
         nTimeStep > 0 ? nothing : error("nTimeStep must be a positive integer")
         volatility >= 0 ? nothing : error("volatility cannot be negative")
         new(nTimeStep, initial, volatility, drift)
     end
     # constructor for ordered inputs
-    function LogDiffInput(nTimeStep, initial, volatility, drift)
+    function LogDiffInput{TI,TR}(nTimeStep, initial, volatility, drift) where {TI,TR}
         nTimeStep > 0 ? nothing : error("nTimeStep must be a positive integer")
         volatility >= 0 ? nothing : error("volatility cannot be negative")
         new(nTimeStep, initial, volatility, drift)
     end
 end
 # outer constructor for passing just nTimeStep
-LogDiffInput(nTimeStep::Int; initial = 100, volatility = 0.3, drift = 0.02) =
-    LogDiffInput(nTimeStep, initial, volatility, drift)
+function LogDiffInput(nTimeStep; initial = 100, volatility = 0.3, drift = 0.02)
+    TI = typeof(nTimeStep)
+    TR = typeof(initial)
+    volatility = convert(TR, volatility)
+    drift = convert(TR, drift)
+    return LogDiffInput{TI,TR}(nTimeStep, initial, volatility, drift)
+end
 
-
-function makedata(Input::LogDiffInput, nSimulation::Integer = 1)
+function makedata(Input::LogDiffInput, nSimulation = 1)
 
     # compute array of random values
     nData = Input.nTimeStep + 1

--- a/src/DataGeneration/logdiffusion.jl
+++ b/src/DataGeneration/logdiffusion.jl
@@ -4,7 +4,6 @@ import Distributions.Normal
 
 """
     LogDiffInput(nTimeStep, initial, volatility, drift)
-    LogDiffInput(nTimeStep; kwargs...)
     LogDiffInput(;kwargs...)
 
 Contains parameters that are used by `makedata()` to synthesize data
@@ -65,12 +64,20 @@ struct LogDiffInput{TI,TR} <: DataGenInput
     end
 end
 # outer constructor for passing just nTimeStep
-function LogDiffInput(nTimeStep; initial = 100, volatility = 0.3, drift = 0.02)
+function LogDiffInput(nTimeStep, initial = 100, volatility = 0.3, drift = 0.02)
     TI = typeof(nTimeStep)
     initial, volatility, drift = promote(initial, volatility, drift)
     TR = typeof(initial)
     return LogDiffInput{TI,TR}(nTimeStep, initial, volatility, drift)
 end
+function LogDiffInput(;nTimeStep, initial = 100, volatility = 0.3, drift = 0.02)
+    TI = typeof(nTimeStep)
+    initial, volatility, drift = promote(initial, volatility, drift)
+    TR = typeof(initial)
+    return LogDiffInput{TI,TR}(nTimeStep, initial, volatility, drift)
+end
+
+
 
 function makedata(Input::LogDiffInput, nSimulation = 1)
 

--- a/src/DataGeneration/logdiffusion.jl
+++ b/src/DataGeneration/logdiffusion.jl
@@ -67,9 +67,8 @@ end
 # outer constructor for passing just nTimeStep
 function LogDiffInput(nTimeStep; initial = 100, volatility = 0.3, drift = 0.02)
     TI = typeof(nTimeStep)
+    initial, volatility, drift = promote(initial, volatility, drift)
     TR = typeof(initial)
-    volatility = convert(TR, volatility)
-    drift = convert(TR, drift)
     return LogDiffInput{TI,TR}(nTimeStep, initial, volatility, drift)
 end
 

--- a/src/DataGeneration/logdiffusion.jl
+++ b/src/DataGeneration/logdiffusion.jl
@@ -21,10 +21,10 @@ then shifted and scaled by the drift and volatility terms.
 
 ## Arguments
 
-- `nTimeStep::Int64`:  The number of time steps to synthesize.
-- `initial::Float64`:  The assumed value at the 0th time step. Default: 100.
-- `volatility::Float64`:  The price volatility as a standard deviation in terms of implied time period. Defaults to 0.3.
-- `drift::Float64`: The drift parameter describes the mean of the log-normal diffusion process 
+- `nTimeStep`:  The number of time steps to synthesize.
+- `initial`:  The assumed value at the 0th time step. Default: 100.
+- `volatility`:  The price volatility as a standard deviation in terms of implied time period. Defaults to 0.3.
+- `drift`: The drift parameter describes the mean of the log-normal diffusion process 
 given in terms of the entire implied time period (if simulating a year, drift would be annual 
 expected return). Defaults to 0.02.
 

--- a/src/Instruments/financial_instruments.jl
+++ b/src/Instruments/financial_instruments.jl
@@ -78,10 +78,9 @@ end
 # Outer constructors for passing only the widget
 """
     EuroCallOption(;kwargs...)
-    EuroCallOption{T<:Widget}(;kwargs...)
-    EuroCallOption{T<:Widget}(widget, strike_price, maturity, risk_free_rate, values_library)
+    EuroCallOption(widget, strike_price, maturity, risk_free_rate, values_library)
 
-Construct a EuroCallOption with underlying asset `T`.
+Construct a EuroCallOption with underlying asset of type `Widget`
 
 ## Arguments
 - `widget`: underlying asset
@@ -136,7 +135,7 @@ end
 """
     AmericanCallOption{T <: Widget} <: CallOption{T}
 
-American call option with underlying asset `T`. 
+American call option with underlying asset of type `T`
 """
 struct AmericanCallOption{T<:Widget,S,D} <: CallOption{T}
     widget::T
@@ -185,10 +184,8 @@ end
 """
     AmericanCallOption(widget, strike_price; kwargs...)
     AmericanCallOption(;kwargs...)
-    AmericanCallOption{T<:Widget}(;kwargs...)
-    AmericanCallOption{T<:Widget}(widget, strike_price, maturity, risk_free_rate, values_library)
 
-Construct a AmericanCallOption with underlying asset `T`.
+Construct a AmericanCallOption with underlying asset of type `Widget`
 
 ## Arguments
 - `widget::Widget`: The underlying asset
@@ -293,10 +290,8 @@ end
 """
     EuroPutOption(widget, strike_price; kwargs...)
     EuroPutOption(;kwargs...)
-    EuroPutOption{T<:Widget}(;kwargs...)
-    EuroPutOption{T<:Widget}(widget, strike_price, maturity, risk_free_rate, values_library)
 
-Construct a EuroPutOption with underlying asset `T`. 
+Construct a EuroPutOption with underlying asset of type `Widget`
 
 ## Arguments
 - `widget::Widget`: The underlying asset.
@@ -403,10 +398,8 @@ end
 """
     AmericanPutOption(widget, strike_price; kwargs...)
     AmericanPutOption(;kwargs...)
-    AmericanPutOption{T<:Widget}(;kwargs...)
-    AmericanPutOption{T<:Widget}(widget, strike_price, maturity, risk_free_rate, values_library)
 
-Construct an AmericanPutOption with underlying asset `T` 
+Construct an AmericanPutOption with underlying asset of type `Widget`
 
 ## Arguments
 - `widget::Widget`: underlying asset

--- a/src/Instruments/financial_instruments.jl
+++ b/src/Instruments/financial_instruments.jl
@@ -34,12 +34,11 @@ European call option with underlying asset `T`.
 """
 struct EuroCallOption{T<:Widget} <: CallOption{T}
     widget::T
-    strike_price::AbstractFloat
-    maturity::AbstractFloat
-    risk_free_rate::AbstractFloat
-
+    strike_price::Float64
+    maturity::Float64
+    risk_free_rate::Float64
     label::String
-    values_library::Dict{String,Dict{String,AbstractFloat}}
+    values_library::Dict{String,Dict{String,Float64}}
 
     # kwargs constructor
     function EuroCallOption{T}(;
@@ -48,11 +47,11 @@ struct EuroCallOption{T<:Widget} <: CallOption{T}
         maturity = 1,
         risk_free_rate = 0.02,
         label = "",
-        values_library = Dict{String,Dict{String,AbstractFloat}}(),
+        values_library = Dict{String,Dict{String,Float64}}(),
     ) where {T<:Widget}
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive ", maturity)
-        values_library == Dict{String,Dict{String,AbstractFloat}}() ? nothing :
+        values_library == Dict{String,Dict{String,Float64}}() ? nothing :
         @warn("It is not recommended to pass values through the constructor. \
         price!(Instrument, pricing_model) should be used")
         new{T}(widget, strike_price, maturity, risk_free_rate, label, values_library)
@@ -69,7 +68,7 @@ struct EuroCallOption{T<:Widget} <: CallOption{T}
     ) where {T<:Widget}
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive")
-        values_library == Dict{String,Dict{String,AbstractFloat}}() ? nothing :
+        values_library == Dict{String,Dict{String,Float64}}() ? nothing :
         @warn("It is not recommended to pass values through the constructor. \
         price!(Instrument, pricing_model) should be used")
 
@@ -110,7 +109,7 @@ EuroCallOption(
     maturity = 1,
     risk_free_rate = 0.02,
     label = "",
-    values_library = Dict{String,Dict{String,AbstractFloat}}(),
+    values_library = Dict{String,Dict{String,Float64}}(),
 ) = EuroCallOption{typeof(widget)}(;
     widget = widget,
     strike_price = strike_price,
@@ -125,7 +124,7 @@ EuroCallOption(
     strike_price::Real,
     maturity::Real,
     label::String,
-    values_library::Dict{String,Dict{String,AbstractFloat}},
+    values_library::Dict{String,Dict{String,Float64}},
 ) = EuroCallOption{typeof(widget)}(;
     widget = widget,
     strik_price = strike_price,
@@ -140,7 +139,7 @@ EuroCallOption(;
     maturity = 1,
     risk_free_rate = 0.02,
     label = "",
-    values_library = Dict{String,Dict{String,AbstractFloat}}(),
+    values_library = Dict{String,Dict{String,Float64}}(),
 ) = EuroCallOption{typeof(widget)}(;
     widget = widget,
     strike_price = strike_price,
@@ -157,12 +156,12 @@ American call option with underlying asset `T`.
 """
 struct AmericanCallOption{T<:Widget} <: CallOption{T}
     widget::T
-    strike_price::AbstractFloat
-    maturity::AbstractFloat
-    risk_free_rate::AbstractFloat
+    strike_price::Float64
+    maturity::Float64
+    risk_free_rate::Float64
 
     label::String
-    values_library::Dict{String,Dict{String,AbstractFloat}}
+    values_library::Dict{String,Dict{String,Float64}}
 
     # kwargs constructor
     function AmericanCallOption{T}(;
@@ -171,11 +170,11 @@ struct AmericanCallOption{T<:Widget} <: CallOption{T}
         maturity = 1,
         risk_free_rate = 0.02,
         label = "",
-        values_library = Dict{String,Dict{String,AbstractFloat}}(),
+        values_library = Dict{String,Dict{String,Float64}}(),
     ) where {T<:Widget}
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive")
-        values_library == Dict{String,Dict{String,AbstractFloat}}() ? nothing :
+        values_library == Dict{String,Dict{String,Float64}}() ? nothing :
         @warn("It is not recommended to pass values through the constructor. \
         price!(Instrument, pricing_model) should be used")
         new{T}(widget, strike_price, maturity, risk_free_rate, label, values_library)
@@ -192,7 +191,7 @@ struct AmericanCallOption{T<:Widget} <: CallOption{T}
     ) where {T<:Widget}
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive")
-        values_library == Dict{String,Dict{String,AbstractFloat}}() ? nothing :
+        values_library == Dict{String,Dict{String,Float64}}() ? nothing :
         @warn("It is not recommended to pass values through the constructor. \
         price!(Instrument, pricing_model) should be used")
         new{T}(widget, strike_price, maturity, risk_free_rate, label, values_library)
@@ -232,7 +231,7 @@ AmericanCallOption(
     maturity = 1,
     risk_free_rate = 0.02,
     label = "",
-    values_library = Dict{String,Dict{String,AbstractFloat}}(),
+    values_library = Dict{String,Dict{String,Float64}}(),
 ) = AmericanCallOption{typeof(widget)}(;
     widget = widget,
     strike_price = strike_price,
@@ -248,7 +247,7 @@ AmericanCallOption(
     maturity::Real,
     risk_free_rate::Real,
     label::String,
-    values_library::Dict{String,Dict{String,AbstractFloat}},
+    values_library::Dict{String,Dict{String,Float64}},
 ) = AmericanCallOption{typeof(widget)}(;
     widget = widget,
     strik_price = strike_price,
@@ -264,7 +263,7 @@ AmericanCallOption(;
     maturity = 1,
     risk_free_rate = 0.02,
     label = "",
-    values_library = Dict{String,Dict{String,AbstractFloat}}(),
+    values_library = Dict{String,Dict{String,Float64}}(),
 ) = AmericanCallOption{typeof(widget)}(;
     widget = widget,
     strike_price = strike_price,
@@ -280,12 +279,12 @@ European put option with underlying asset `T`.
 """
 struct EuroPutOption{T<:Widget} <: PutOption{T}
     widget::T
-    strike_price::AbstractFloat
-    maturity::AbstractFloat
-    risk_free_rate::AbstractFloat
+    strike_price::Float64
+    maturity::Float64
+    risk_free_rate::Float64
 
     label::String
-    values_library::Dict{String,Dict{String,AbstractFloat}}
+    values_library::Dict{String,Dict{String,Float64}}
 
     # kwargs constructor
     function EuroPutOption{T}(;
@@ -294,11 +293,11 @@ struct EuroPutOption{T<:Widget} <: PutOption{T}
         maturity = 1,
         risk_free_rate = 0.02,
         label = "",
-        values_library = Dict{String,Dict{String,AbstractFloat}}(),
+        values_library = Dict{String,Dict{String,Float64}}(),
     ) where {T<:Widget}
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive")
-        values_library == Dict{String,Dict{String,AbstractFloat}}() ? nothing :
+        values_library == Dict{String,Dict{String,Float64}}() ? nothing :
         @warn("It is not recommended to pass values through the constructor. \
         price!(Instrument, pricing_model) should be used")
 
@@ -316,7 +315,7 @@ struct EuroPutOption{T<:Widget} <: PutOption{T}
     ) where {T<:Widget}
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive")
-        values_library == Dict{String,Dict{String,AbstractFloat}}() ? nothing :
+        values_library == Dict{String,Dict{String,Float64}}() ? nothing :
         @warn("It is not recommended to pass values through the constructor. \
         price!(Instrument, pricing_model) should be used")
 
@@ -357,7 +356,7 @@ EuroPutOption(
     maturity = 1,
     risk_free_rate = 0.02,
     label = "",
-    values_library = Dict{String,Dict{String,AbstractFloat}}(),
+    values_library = Dict{String,Dict{String,Float64}}(),
 ) = EuroPutOption{typeof(widget)}(;
     widget = widget,
     strike_price = strike_price,
@@ -373,7 +372,7 @@ EuroPutOption(
     maturity::Real,
     risk_free_rate::Real,
     label::String,
-    values_library::Dict{String,Dict{String,AbstractFloat}},
+    values_library::Dict{String,Dict{String,Float64}},
 ) = EuroPutOption{typeof(widget)}(;
     widget = widget,
     strik_price = strike_price,
@@ -389,7 +388,7 @@ EuroPutOption(;
     maturity = 1,
     risk_free_rate = 0.02,
     label = "",
-    values_library = Dict{String,Dict{String,AbstractFloat}}(),
+    values_library = Dict{String,Dict{String,Float64}}(),
 ) = EuroPutOption{typeof(widget)}(;
     widget = widget,
     strike_price = strike_price,
@@ -406,12 +405,12 @@ American put option with underlying asset `T`.
 """
 struct AmericanPutOption{T<:Widget} <: PutOption{T}
     widget::T
-    strike_price::AbstractFloat
-    maturity::AbstractFloat
-    risk_free_rate::AbstractFloat
+    strike_price::Float64
+    maturity::Float64
+    risk_free_rate::Float64
 
     label::String
-    values_library::Dict{String,Dict{String,AbstractFloat}}
+    values_library::Dict{String,Dict{String,Float64}}
 
     # kwargs constructor
     function AmericanPutOption{T}(;
@@ -420,12 +419,12 @@ struct AmericanPutOption{T<:Widget} <: PutOption{T}
         maturity = 1,
         risk_free_rate = 0.02,
         label = "",
-        values_library = Dict{String,Dict{String,AbstractFloat}}(),
+        values_library = Dict{String,Dict{String,Float64}}(),
     ) where {T<:Widget}
 
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive")
-        values_library == Dict{String,Dict{String,AbstractFloat}}() ? nothing :
+        values_library == Dict{String,Dict{String,Float64}}() ? nothing :
         @warn("It is not recommended to pass values through the constructor. \
         price!(Instrument, pricing_model) should be used")
 
@@ -444,7 +443,7 @@ struct AmericanPutOption{T<:Widget} <: PutOption{T}
 
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive")
-        values_library == Dict{String,Dict{String,AbstractFloat}}() ? nothing :
+        values_library == Dict{String,Dict{String,Float64}}() ? nothing :
         @warn("It is not recommended to pass values through the constructor. \
         price!(Instrument, pricing_model) should be used")
 
@@ -485,7 +484,7 @@ AmericanPutOption(
     maturity = 1,
     risk_free_rate = 0.02,
     label = "",
-    values_library = Dict{String,Dict{String,AbstractFloat}}(),
+    values_library = Dict{String,Dict{String,Float64}}(),
 ) = AmericanPutOption{typeof(widget)}(;
     widget = widget,
     strike_price = strike_price,
@@ -500,7 +499,7 @@ AmericanPutOption(
     strike_price::Real,
     maturity::Real,
     risk_free_rate::Real,
-    values_library::Dict{String,Dict{String,AbstractFloat}},
+    values_library::Dict{String,Dict{String,Float64}},
 ) = AmericanPutOption{typeof(widget)}(;
     widget = widget,
     strik_price = strike_price,
@@ -516,7 +515,7 @@ AmericanPutOption(;
     maturity = 1,
     risk_free_rate = 0.02,
     label = "",
-    values_library = Dict{String,Dict{String,AbstractFloat}}(),
+    values_library = Dict{String,Dict{String,Float64}}(),
 ) = AmericanPutOption{typeof(widget)}(;
     widget = widget,
     strike_price = strike_price,
@@ -536,11 +535,11 @@ Future contract with underlying asset 'T'.
 """
 struct Future{T<:Widget} <: FinancialInstrument
     widget::T
-    strike_price::AbstractFloat
-    risk_free_rate::AbstractFloat
-    maturity::AbstractFloat
+    strike_price::Float64
+    risk_free_rate::Float64
+    maturity::Float64
     label::String
-    values_library::Dict{String,Dict{String,AbstractFloat}}
+    values_library::Dict{String,Dict{String,Float64}}
 end
 
 # ------ Type system for stuff we haven't figured out yet ------ 

--- a/src/Instruments/financial_instruments.jl
+++ b/src/Instruments/financial_instruments.jl
@@ -165,7 +165,7 @@ struct AmericanCallOption{T<:Widget,S,D} <: CallOption{T}
 
     # ordered arguments constructor
     function AmericanCallOption{T,S,D}(
-        widget::T,
+        widget,
         strike_price,
         maturity,
         risk_free_rate,

--- a/src/Instruments/financial_instruments.jl
+++ b/src/Instruments/financial_instruments.jl
@@ -32,53 +32,51 @@ abstract type PutOption{T<:Widget} <: Option end
 
 European call option with underlying asset `T`. 
 """
-struct EuroCallOption{T<:Widget} <: CallOption{T}
+struct EuroCallOption{T<:Widget,S,D} <: CallOption{T}
     widget::T
-    strike_price::Float64
-    maturity::Float64
-    risk_free_rate::Float64
+    strike_price::S
+    maturity::S
+    risk_free_rate::S
     label::String
-    values_library::Dict{String,Dict{String,Float64}}
+    values_library::Dict{String,Dict{String,D}}
 
     # kwargs constructor
-    function EuroCallOption{T}(;
+    function EuroCallOption{T,S,D}(;
         widget,
         strike_price = widget.prices[end],
         maturity = 1,
         risk_free_rate = 0.02,
         label = "",
         values_library = Dict{String,Dict{String,Float64}}(),
-    ) where {T<:Widget}
+    ) where {T<:Widget,S,D}
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive ", maturity)
-        values_library == Dict{String,Dict{String,Float64}}() ? nothing :
+        values_library == Dict{String,Dict{String,D}}() ? nothing :
         @warn("It is not recommended to pass values through the constructor. \
         price!(Instrument, pricing_model) should be used")
-        new{T}(widget, strike_price, maturity, risk_free_rate, label, values_library)
+        new{T,S,D}(widget, strike_price, maturity, risk_free_rate, label, values_library)
     end
 
     # ordered arguments constructor
-    function EuroCallOption{T}(
-        widget::T,
+    function EuroCallOption{T,S,D}(
+        widget,
         strike_price,
         maturity,
         risk_free_rate,
         label,
         values_library,
-    ) where {T<:Widget}
+    ) where {T<:Widget,S,D}
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive")
-        values_library == Dict{String,Dict{String,Float64}}() ? nothing :
+        values_library == Dict{String,Dict{String,D}}() ? nothing :
         @warn("It is not recommended to pass values through the constructor. \
         price!(Instrument, pricing_model) should be used")
-
-        new{T}(widget, strike_price, maturity, risk_free_rate, label, values_library)
+        new{T,S,D}(widget, strike_price, maturity, risk_free_rate, label, values_library)
     end
 end
 
 # Outer constructors for passing only the widget
 """
-    EuroCallOption(widget, strike_price; kwargs...)
     EuroCallOption(;kwargs...)
     EuroCallOption{T<:Widget}(;kwargs...)
     EuroCallOption{T<:Widget}(widget, strike_price, maturity, risk_free_rate, values_library)
@@ -86,7 +84,7 @@ end
 Construct a EuroCallOption with underlying asset `T`.
 
 ## Arguments
-- `widget::Widget`: underlying asset
+- `widget`: underlying asset
 - `strike_price`: Contracted price to buy underlying asset at maturity
 - `maturity`: time to maturity of the option with respect to implicit time period. Default 1.
 - `risk_free_rate`: market risk free interest rate. Default is .02.
@@ -103,98 +101,83 @@ kwargs = Dict(:widget=>stock, :strike_price=>10, :maturity=>1, :risk_free_rate=>
 EuroCallOption(;kwargs...)
 ```
 """
-EuroCallOption(
-    widget::Widget,
-    strike_price::Real = widget.prices[end];
-    maturity = 1,
-    risk_free_rate = 0.02,
-    label = "",
-    values_library = Dict{String,Dict{String,Float64}}(),
-) = EuroCallOption{typeof(widget)}(;
-    widget = widget,
-    strike_price = strike_price,
-    maturity = maturity,
-    risk_free_rate = risk_free_rate,
-    label = label,
-    values_library = values_library,
-)
-
-EuroCallOption(
-    widget::Widget,
-    strike_price::Real,
-    maturity::Real,
-    label::String,
-    values_library::Dict{String,Dict{String,Float64}},
-) = EuroCallOption{typeof(widget)}(;
-    widget = widget,
-    strik_price = strike_price,
-    maturity = maturity,
-    label = label,
-    values_library = values_library,
-)
-
-EuroCallOption(;
+function EuroCallOption(
     widget,
     strike_price = widget.prices[end],
     maturity = 1,
     risk_free_rate = 0.02,
     label = "",
     values_library = Dict{String,Dict{String,Float64}}(),
-) = EuroCallOption{typeof(widget)}(;
-    widget = widget,
-    strike_price = strike_price,
-    maturity = maturity,
-    risk_free_rate = risk_free_rate,
-    label = label,
-    values_library = values_library,
 )
+    T = typeof(widget)
+    strike_price, maturity, risk_free_rate = promote(strike_price, maturity, risk_free_rate)
+    S = typeof(strike_price)
+    D = valtype(valtype(values_library))
+
+    return EuroCallOption{T,S,D}(widget, strike_price, maturity, risk_free_rate, label, values_library)
+end
+
+function EuroCallOption(;
+    widget,
+    strike_price = widget.prices[end],
+    maturity = 1,
+    risk_free_rate = 0.02,
+    label = "",
+    values_library = Dict{String,Dict{String,Float64}}()
+)
+    T = typeof(widget)
+    strike_price, maturity, risk_free_rate = promote(strike_price, maturity, risk_free_rate)
+    S = typeof(strike_price)
+    D = valtype(valtype(values_library))
+
+    return EuroCallOption{T,S,D}(widget, strike_price, maturity, risk_free_rate, label, values_library)
+end
 
 """
     AmericanCallOption{T <: Widget} <: CallOption{T}
 
 American call option with underlying asset `T`. 
 """
-struct AmericanCallOption{T<:Widget} <: CallOption{T}
+struct AmericanCallOption{T<:Widget,S,D} <: CallOption{T}
     widget::T
-    strike_price::Float64
-    maturity::Float64
-    risk_free_rate::Float64
-
+    strike_price::S
+    maturity::S
+    risk_free_rate::S
     label::String
-    values_library::Dict{String,Dict{String,Float64}}
+    values_library::Dict{String,Dict{String,D}}
 
     # kwargs constructor
-    function AmericanCallOption{T}(;
+    function AmericanCallOption{T,S,D}(;
         widget,
         strike_price = widget.prices[end],
         maturity = 1,
         risk_free_rate = 0.02,
         label = "",
         values_library = Dict{String,Dict{String,Float64}}(),
-    ) where {T<:Widget}
+    ) where {T<:Widget,S,D}
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive")
-        values_library == Dict{String,Dict{String,Float64}}() ? nothing :
+        values_library == Dict{String,Dict{String,D}}() ? nothing :
         @warn("It is not recommended to pass values through the constructor. \
         price!(Instrument, pricing_model) should be used")
-        new{T}(widget, strike_price, maturity, risk_free_rate, label, values_library)
+        new{T,S,D}(widget, strike_price, maturity, risk_free_rate, label, values_library)
     end
 
     # ordered arguments constructor
-    function AmericanCallOption{T}(
+    function AmericanCallOption{T,S,D}(
         widget::T,
         strike_price,
         maturity,
         risk_free_rate,
         label,
         values_library,
-    ) where {T<:Widget}
+    ) where {T<:Widget,S,D}
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive")
-        values_library == Dict{String,Dict{String,Float64}}() ? nothing :
+        values_library == Dict{String,Dict{String,D}}() ? nothing :
         @warn("It is not recommended to pass values through the constructor. \
         price!(Instrument, pricing_model) should be used")
-        new{T}(widget, strike_price, maturity, risk_free_rate, label, values_library)
+        new{T,S,D}(widget, strike_price, maturity, risk_free_rate, label, values_library)
     end
 end
 
@@ -225,105 +208,88 @@ kwargs= Dict(:widget=>stock, :strike_price=>10, :maturity=>1, :risk_free_rate=>.
 AmericanCallOption(;kwargs...)
 ```
 """
-AmericanCallOption(
-    widget::Widget,
-    strike_price::Real = widget.prices[end];
-    maturity = 1,
-    risk_free_rate = 0.02,
-    label = "",
-    values_library = Dict{String,Dict{String,Float64}}(),
-) = AmericanCallOption{typeof(widget)}(;
-    widget = widget,
-    strike_price = strike_price,
-    maturity = maturity,
-    risk_free_rate = risk_free_rate,
-    label = label,
-    values_library = values_library,
-)
-
-AmericanCallOption(
-    widget::Widget,
-    strike_price::Real,
-    maturity::Real,
-    risk_free_rate::Real,
-    label::String,
-    values_library::Dict{String,Dict{String,Float64}},
-) = AmericanCallOption{typeof(widget)}(;
-    widget = widget,
-    strik_price = strike_price,
-    maturity = maturity,
-    risk_free_rate = risk_free_rate,
-    label = label,
-    values_library = values_library,
-)
-
-AmericanCallOption(;
+function AmericanCallOption(
     widget,
     strike_price = widget.prices[end],
     maturity = 1,
     risk_free_rate = 0.02,
     label = "",
     values_library = Dict{String,Dict{String,Float64}}(),
-) = AmericanCallOption{typeof(widget)}(;
-    widget = widget,
-    strike_price = strike_price,
-    maturity = maturity,
-    risk_free_rate = risk_free_rate,
-    label = label,
-    values_library = values_library,
+)    
+    T = typeof(widget)
+    strike_price, maturity, risk_free_rate = promote(strike_price, maturity, risk_free_rate)
+    S = typeof(strike_price)
+    D = valtype(valtype(values_library))
+
+    return AmericanCallOption{T,S,D}(widget, strike_price, maturity, risk_free_rate, label, values_library)
+end
+
+function AmericanCallOption(;
+    widget,
+    strike_price = widget.prices[end],
+    maturity = 1,
+    risk_free_rate = 0.02,
+    label = "",
+    values_library = Dict{String,Dict{String,Float64}}(),
 )
+    T = typeof(widget)
+    strike_price, maturity, risk_free_rate = promote(strike_price, maturity, risk_free_rate)
+    S = typeof(strike_price)
+    D = valtype(valtype(values_library))
+
+    return AmericanCallOption{T,S,D}(widget, strike_price, maturity, risk_free_rate, label, values_library)
+end
 
 """
     EuroPutOption{T <: Widget} <: CallOption{T}
 European put option with underlying asset `T`. 
 """
-struct EuroPutOption{T<:Widget} <: PutOption{T}
+struct EuroPutOption{T<:Widget,S,D} <: PutOption{T}
     widget::T
-    strike_price::Float64
-    maturity::Float64
-    risk_free_rate::Float64
-
+    strike_price::S
+    maturity::S
+    risk_free_rate::S
     label::String
-    values_library::Dict{String,Dict{String,Float64}}
+    values_library::Dict{String,Dict{String,D}}
 
     # kwargs constructor
-    function EuroPutOption{T}(;
+    function EuroPutOption{T,S,D}(;
         widget,
         strike_price = widget.prices[end],
         maturity = 1,
         risk_free_rate = 0.02,
         label = "",
         values_library = Dict{String,Dict{String,Float64}}(),
-    ) where {T<:Widget}
+    ) where {T<:Widget,S,D}
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive")
-        values_library == Dict{String,Dict{String,Float64}}() ? nothing :
+        values_library == Dict{String,Dict{String,D}}() ? nothing :
         @warn("It is not recommended to pass values through the constructor. \
         price!(Instrument, pricing_model) should be used")
 
-        new{T}(widget, strike_price, maturity, risk_free_rate, label, values_library)
+        new{T,S,D}(widget, strike_price, maturity, risk_free_rate, label, values_library)
     end
 
     # ordered arguments constructor
-    function EuroPutOption{T}(
-        widget::T,
+    function EuroPutOption{T,S,D}(
+        widget,
         strike_price,
         maturity,
         risk_free_rate,
         label,
         values_library,
-    ) where {T<:Widget}
+    ) where {T<:Widget,S,D}
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive")
-        values_library == Dict{String,Dict{String,Float64}}() ? nothing :
+        values_library == Dict{String,Dict{String,D}}() ? nothing :
         @warn("It is not recommended to pass values through the constructor. \
         price!(Instrument, pricing_model) should be used")
 
-        new{T}(widget, strike_price, maturity, risk_free_rate, label, values_library)
+        new{T,S,D}(widget, strike_price, maturity, risk_free_rate, label, values_library)
     end
 end
 
-# Outer constructors for passing only the widget
+# Outer constructors
 """
     EuroPutOption(widget, strike_price; kwargs...)
     EuroPutOption(;kwargs...)
@@ -350,96 +316,78 @@ kwargs= Dict(:widget=>stock, :strike_price=>10, :maturity=>1, :risk_free_rate=>.
 EuroPutOption(;kwargs...)
 ```
 """
-EuroPutOption(
-    widget::Widget,
-    strike_price::Real = widget.prices[end];
-    maturity = 1,
-    risk_free_rate = 0.02,
-    label = "",
-    values_library = Dict{String,Dict{String,Float64}}(),
-) = EuroPutOption{typeof(widget)}(;
-    widget = widget,
-    strike_price = strike_price,
-    maturity = maturity,
-    risk_free_rate = risk_free_rate,
-    label = label,
-    values_library = values_library,
-)
-
-EuroPutOption(
-    widget::Widget,
-    strike_price::Real,
-    maturity::Real,
-    risk_free_rate::Real,
-    label::String,
-    values_library::Dict{String,Dict{String,Float64}},
-) = EuroPutOption{typeof(widget)}(;
-    widget = widget,
-    strik_price = strike_price,
-    maturity = maturity,
-    risk_free_rate = risk_free_rate,
-    label,
-    values_library = values_library,
-)
-
-EuroPutOption(;
+function EuroPutOption(
     widget,
     strike_price = widget.prices[end],
     maturity = 1,
     risk_free_rate = 0.02,
     label = "",
     values_library = Dict{String,Dict{String,Float64}}(),
-) = EuroPutOption{typeof(widget)}(;
-    widget = widget,
-    strike_price = strike_price,
-    maturity = maturity,
-    risk_free_rate = risk_free_rate,
-    label = label,
-    values_library = values_library,
 )
+    T = typeof(widget)
+    strike_price, maturity, risk_free_rate = promote(strike_price, maturity, risk_free_rate)
+    S = typeof(strike_price)
+    D = valtype(valtype(values_library))
+
+    return EuroPutOption{T,S,D}(widget, strike_price,maturity,risk_free_rate,label,values_library)
+end
+
+function EuroPutOption(;
+    widget,
+    strike_price = widget.prices[end],
+    maturity = 1,
+    risk_free_rate = 0.02,
+    label = "",
+    values_library = Dict{String,Dict{String,Float64}}(),
+)
+    T = typeof(widget)
+    strike_price, maturity, risk_free_rate = promote(strike_price, maturity, risk_free_rate)
+    S = typeof(strike_price)
+    D = valtype(valtype(values_library))
+
+    return EuroPutOption{T,S,D}(widget, strike_price, maturity, risk_free_rate, label, values_library)
+end
 
 """
     AmericanPutOption{T <: Widget} <: CallOption{T}
 
 American put option with underlying asset `T`. 
 """
-struct AmericanPutOption{T<:Widget} <: PutOption{T}
+struct AmericanPutOption{T<:Widget,S,D} <: PutOption{T}
     widget::T
-    strike_price::Float64
-    maturity::Float64
-    risk_free_rate::Float64
-
+    strike_price::S
+    maturity::S
+    risk_free_rate::S
     label::String
-    values_library::Dict{String,Dict{String,Float64}}
+    values_library::Dict{String,Dict{String,D}}
 
     # kwargs constructor
-    function AmericanPutOption{T}(;
+    function AmericanPutOption{T,S,D}(;
         widget,
         strike_price = widget.prices[end],
         maturity = 1,
         risk_free_rate = 0.02,
         label = "",
         values_library = Dict{String,Dict{String,Float64}}(),
-    ) where {T<:Widget}
+    ) where {T<:Widget,S,D}
 
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive")
-        values_library == Dict{String,Dict{String,Float64}}() ? nothing :
+        values_library == Dict{String,Dict{String,D}}() ? nothing :
         @warn("It is not recommended to pass values through the constructor. \
         price!(Instrument, pricing_model) should be used")
-
-        new{T}(widget, strike_price, maturity, risk_free_rate, label, values_library)
+        new{T,S,D}(widget, strike_price, maturity, risk_free_rate, label, values_library)
     end
 
     # ordered arguments constructor
-    function AmericanPutOption{T}(
-        widget::T,
+    function AmericanPutOption{T,S,D}(
+        widget,
         strike_price,
         maturity,
         risk_free_rate,
         label,
         values_library,
-    ) where {T<:Widget}
+    ) where {T<:Widget,S,D}
 
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive")
@@ -447,7 +395,7 @@ struct AmericanPutOption{T<:Widget} <: PutOption{T}
         @warn("It is not recommended to pass values through the constructor. \
         price!(Instrument, pricing_model) should be used")
 
-        new{T}(widget, strike_price, maturity, risk_free_rate, label, values_library)
+        new{T,S,D}(widget, strike_price, maturity, risk_free_rate, label, values_library)
     end
 end
 
@@ -478,54 +426,37 @@ kwargs = Dict(:widget=>stock, :strike_price=>10, :maturity=>1, :risk_free_rate=>
 AmericanPutOption(;kwargs...)
 ```
 """
-AmericanPutOption(
-    widget::Widget,
-    strike_price::Real = widget.prices[end];
-    maturity = 1,
-    risk_free_rate = 0.02,
-    label = "",
-    values_library = Dict{String,Dict{String,Float64}}(),
-) = AmericanPutOption{typeof(widget)}(;
-    widget = widget,
-    strike_price = strike_price,
-    maturity = maturity,
-    risk_free_rate = risk_free_rate,
-    label = label,
-    values_library = values_library,
-)
-
-AmericanPutOption(
-    widget::Widget,
-    strike_price::Real,
-    maturity::Real,
-    risk_free_rate::Real,
-    values_library::Dict{String,Dict{String,Float64}},
-) = AmericanPutOption{typeof(widget)}(;
-    widget = widget,
-    strik_price = strike_price,
-    maturity = maturity,
-    risk_free_rate = risk_free_rate,
-    label = label,
-    values_library = values_library,
-)
-
-AmericanPutOption(;
+function AmericanPutOption(
     widget,
     strike_price = widget.prices[end],
     maturity = 1,
     risk_free_rate = 0.02,
     label = "",
     values_library = Dict{String,Dict{String,Float64}}(),
-) = AmericanPutOption{typeof(widget)}(;
-    widget = widget,
-    strike_price = strike_price,
-    maturity = maturity,
-    risk_free_rate = risk_free_rate,
-    label = label,
-    values_library = values_library,
+)    
+    T = typeof(widget)
+    strike_price, maturity, risk_free_rate = promote(strike_price, maturity, risk_free_rate)
+    S = typeof(strike_price)
+    D = valtype(valtype(values_library))
+
+    return AmericanPutOption{T,S,D}(widget, strike_price,maturity,risk_free_rate,label,values_library)
+end
+    
+function AmericanPutOption(;
+    widget,
+    strike_price = widget.prices[end],
+    maturity = 1,
+    risk_free_rate = 0.02,
+    label = "",
+    values_library = Dict{String,Dict{String,Float64}}(),
 )
+    T = typeof(widget)
+    strike_price, maturity, risk_free_rate = promote(strike_price, maturity, risk_free_rate)
+    S = typeof(strike_price)
+    D = valtype(valtype(values_library))
 
-
+    return AmericanPutOption{T,S,D}(widget, strike_price,maturity,risk_free_rate,label,values_library)
+end
 
 # ------ Type system for futures: subtype of FinancialInstrument ------
 """
@@ -533,13 +464,13 @@ AmericanPutOption(;
 
 Future contract with underlying asset 'T'.
 """
-struct Future{T<:Widget} <: FinancialInstrument
+struct Future{T<:Widget,S,D} <: FinancialInstrument
     widget::T
-    strike_price::Float64
-    risk_free_rate::Float64
-    maturity::Float64
+    strike_price::S
+    risk_free_rate::S
+    maturity::S
     label::String
-    values_library::Dict{String,Dict{String,Float64}}
+    values_library::Dict{String,Dict{String,D}}
 end
 
 # ------ Type system for stuff we haven't figured out yet ------ 

--- a/src/Instruments/financial_instruments.jl
+++ b/src/Instruments/financial_instruments.jl
@@ -391,7 +391,7 @@ struct AmericanPutOption{T<:Widget,S,D} <: PutOption{T}
 
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive")
-        values_library == Dict{String,Dict{String,Float64}}() ? nothing :
+        values_library == Dict{String,Dict{String,D}}() ? nothing :
         @warn("It is not recommended to pass values through the constructor. \
         price!(Instrument, pricing_model) should be used")
 
@@ -480,7 +480,7 @@ struct ETF <: FinancialInstrument end
 struct InterestRateSwap <: FinancialInstrument end
 
 #------- Helpers
-function add_price_value(a_fin_inst::FinancialInstrument, a_new_price::Real)
+function add_price_value(a_fin_inst::FinancialInstrument, a_new_price)
     a_new_price >= 0 ? nothing :
     @warn("You are trying to add a negative number to a prices list")
     push!(a_fin_inst.widget.prices, a_new_price)

--- a/src/Instruments/financial_instruments.jl
+++ b/src/Instruments/financial_instruments.jl
@@ -188,7 +188,7 @@ end
 Construct a AmericanCallOption with underlying asset of type `Widget`
 
 ## Arguments
-- `widget::Widget`: The underlying asset
+- `widget`: The underlying asset
 - `strike_price`: Contracted price to buy underlying asset at maturity.
 - `maturity`: time to maturity of the option with respect to implicit time period. Default 1.
 - `risk_free_rate`: market risk free interest rate. Default is .02.
@@ -294,7 +294,7 @@ end
 Construct a EuroPutOption with underlying asset of type `Widget`
 
 ## Arguments
-- `widget::Widget`: The underlying asset.
+- `widget`: The underlying asset.
 - `strike_price`: Contracted price to buy underlying asset at maturity.
 - `maturity`: time to maturity of the option with respect to implicit time period. Default 1.
 - `risk_free_rate`: market risk free interest rate. Default is .02.
@@ -402,7 +402,7 @@ end
 Construct an AmericanPutOption with underlying asset of type `Widget`
 
 ## Arguments
-- `widget::Widget`: underlying asset
+- `widget`: underlying asset
 - `strike_price`: Contracted price to buy underlying asset at maturity
 - `maturity`: time to maturity of the option with respect to implicit time period. Default 1.
 - `risk_free_rate`: market risk free interest rate. Default is .02.

--- a/src/Instruments/financial_instruments.jl
+++ b/src/Instruments/financial_instruments.jl
@@ -47,7 +47,7 @@ struct EuroCallOption{T<:Widget,S,D} <: CallOption{T}
         maturity = 1,
         risk_free_rate = 0.02,
         label = "",
-        values_library = Dict{String,Dict{String,Float64}}(),
+        values_library = Dict{String,Dict{String,D}}(),
     ) where {T<:Widget,S,D}
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive ", maturity)
@@ -153,7 +153,7 @@ struct AmericanCallOption{T<:Widget,S,D} <: CallOption{T}
         maturity = 1,
         risk_free_rate = 0.02,
         label = "",
-        values_library = Dict{String,Dict{String,Float64}}(),
+        values_library = Dict{String,Dict{String,D}}(),
     ) where {T<:Widget,S,D}
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive")
@@ -259,7 +259,7 @@ struct EuroPutOption{T<:Widget,S,D} <: PutOption{T}
         maturity = 1,
         risk_free_rate = 0.02,
         label = "",
-        values_library = Dict{String,Dict{String,Float64}}(),
+        values_library = Dict{String,Dict{String,D}}(),
     ) where {T<:Widget,S,D}
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive")
@@ -368,7 +368,7 @@ struct AmericanPutOption{T<:Widget,S,D} <: PutOption{T}
         maturity = 1,
         risk_free_rate = 0.02,
         label = "",
-        values_library = Dict{String,Dict{String,Float64}}(),
+        values_library = Dict{String,Dict{String,D}}(),
     ) where {T<:Widget,S,D}
 
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")

--- a/src/Instruments/widgets.jl
+++ b/src/Instruments/widgets.jl
@@ -77,6 +77,7 @@ end
 # outer constructor to make a stock with a (static) single price
 """
     Stock(prices, name, timesteps_per_period, volatility)
+    Stock(price; kwargs...)
     Stock(;kwargs)
 
 Construct a Stock type to use as a base asset for FinancialInstrument.
@@ -130,7 +131,7 @@ function Stock(
     return Stock{T,TI,TF}(prices, name, timesteps_per_period, volatility)
 end
 function Stock(;
-        prices,
+        prices::Vector,
         name = "",
         timesteps_per_period = length(prices),
         volatility = get_volatility(prices, timesteps_per_period),
@@ -211,6 +212,7 @@ end
 # outer constructor to make a Commodity with a (static) single price
 """
     Commodity(prices, name, timesteps_per_period, volatility)
+    commodity(price; kwargs...)
     Commodity(;kwargs)
 
 Construct a Commodity type to use as a base asset for FinancialInstrument.
@@ -306,6 +308,7 @@ end
 # outer constructor to make a Bond with a (static) single price
 """
     Bond(prices, name, time_mat, coupon_rate)
+    Bond(price; kwargs...)
     Bond(;kwargs)
 
 Construct a Bond type to use as a base asset for FinancialInstrument.
@@ -341,7 +344,7 @@ function Bond(; prices, name = "", time_mat = 1, coupon_rate = 0.03, _...)
     TF = typeof(coupon_rate)
     return Bond{T,TF}(prices, name, time_mat, coupon_rate)
 end
-function Bond(prices, name = "", time_mat = 1, coupon_rate = 0.03)
+function Bond(prices::Vector, name = "", time_mat = 1, coupon_rate = 0.03)
     T = eltype(prices)
     time_mat, coupon_rate = promote(time_mat, coupon_rate)
     TF = typeof(coupon_rate)

--- a/src/Instruments/widgets.jl
+++ b/src/Instruments/widgets.jl
@@ -120,7 +120,7 @@ end
 
 # outer constructor to infer the type used in the prices array
 function Stock(
-    prices,
+    prices::Vector,
     name = "",
     timesteps_per_period = length(prices),
     volatility = get_volatility(prices, timesteps_per_period)
@@ -131,7 +131,7 @@ function Stock(
     return Stock{T,TI,TF}(prices, name, timesteps_per_period, volatility)
 end
 function Stock(;
-        prices::Vector,
+        prices,
         name = "",
         timesteps_per_period = length(prices),
         volatility = get_volatility(prices, timesteps_per_period),

--- a/src/Instruments/widgets.jl
+++ b/src/Instruments/widgets.jl
@@ -332,22 +332,22 @@ Bond(2; coupon_rate=.05)
 function Bond(price; name = "", time_mat = 1, coupon_rate = 0.03)
     prices = [price]
     T = typeof(price)
+    time_mat, coupon_rate = promote(time_mat, coupon_rate)
     TF = typeof(coupon_rate)
-    time_mat = convert(TF, time_mat)
     return Bond{T,TF}(; prices = prices, name = name, time_mat = time_mat, coupon_rate = coupon_rate)
 end
 
 # outer constructor with implied type of prices vector 
 function Bond(; prices, name = "", time_mat = 1, coupon_rate = 0.03, _...)
     T = eltype(prices)
+    time_mat, coupon_rate = promote(time_mat, coupon_rate)
     TF = typeof(coupon_rate)
-    time_mat = convert(TF, time_mat)
     return Bond{T,TF}(prices, name, time_mat, coupon_rate)
 end
 function Bond(prices::Vector, name = "", time_mat = 1, coupon_rate = 0.03)
     T = eltype(prices)
+    time_mat, coupon_rate = promote(time_mat, coupon_rate)
     TF = typeof(coupon_rate)
-    time_mat = convert(TF, time_mat)
     return Bond{T,TF}(prices, name, time_mat, coupon_rate)
 end
 # Helpers 

--- a/src/Instruments/widgets.jl
+++ b/src/Instruments/widgets.jl
@@ -119,7 +119,7 @@ end
 
 # outer constructor to infer the type used in the prices array
 function Stock(
-    prices::Vector,
+    prices,
     name = "",
     timesteps_per_period = length(prices),
     volatility = get_volatility(prices, timesteps_per_period)
@@ -217,8 +217,8 @@ Construct a Commodity type to use as a base asset for FinancialInstrument.
 
 ## Arguments
 - `prices`:Historical prices (input as a 1-D array) or the current price input as a number `<: Real`
-- `name::String`: Name of the commodity or commodity ticker symbol. Default "".
-- `timesteps_per_period::Int64`: For the size of a timestep in the data, the number of 
+- `name`: String name of the commodity or commodity ticker symbol. Default "".
+- `timesteps_per_period`: For the size of a timestep in the data, the number of 
 time steps for a given period of time, cannot be negative. For example, if the period of 
 interest is a year, and daily commodity price data is used, `timesteps_per_period=252`. 
 Defualt is the length of the `prices` array or 0 for a single price (static) Commodity. 
@@ -312,7 +312,7 @@ Construct a Bond type to use as a base asset for FinancialInstrument.
 
 ## Arguments
 - `prices`:Historical prices (input as a 1-D array) or the current price input as a number `<: Real`
-- `name::String`: Name of the Bond or issuing company. Default "".
+- `name`: String name of the Bond or issuing company. Default "".
 - `time_mat`: Time until the bond expires (matures) in years. Default 1.
 - `coupon_rate`: The coupon rate for the bond. Default .03.
 
@@ -341,7 +341,7 @@ function Bond(; prices, name = "", time_mat = 1, coupon_rate = 0.03, _...)
     TF = typeof(coupon_rate)
     return Bond{T,TF}(prices, name, time_mat, coupon_rate)
 end
-function Bond(prices::Vector, name = "", time_mat = 1, coupon_rate = 0.03)
+function Bond(prices, name = "", time_mat = 1, coupon_rate = 0.03)
     T = eltype(prices)
     time_mat, coupon_rate = promote(time_mat, coupon_rate)
     TF = typeof(coupon_rate)
@@ -368,7 +368,7 @@ get_volatility(prices) = get_volatility(prices, length(prices))
 # to make positional arguments work
 get_volatility(prices, timesteps_per_period) = nothing
 
-function add_price_value(a_widget::Widget, a_new_price::Real)
+function add_price_value(a_widget::Widget, a_new_price)
     a_new_price >= 0 ? nothing :
     @warn("You are trying to add a negative number to a prices list")
     push!(a_widget.prices, a_new_price)

--- a/src/Instruments/widgets.jl
+++ b/src/Instruments/widgets.jl
@@ -361,7 +361,6 @@ function get_volatility(prices::Vector, timesteps_per_period)
     length(prices) > 2 ? nothing :
     # need at least three values so std can work
     return error("Must have at least three values to calculate the volatility")  
-    prices = convert(Vector{Float64}, prices)
     returns = [((prices[i+1] - prices[i]) / prices[i]) + 1 for i = 1:(length(prices)-1)]
     cont_return = log.(returns)
     std(cont_return, corrected = false) * sqrt(timesteps_per_period)

--- a/src/Instruments/widgets.jl
+++ b/src/Instruments/widgets.jl
@@ -78,7 +78,6 @@ end
 """
     Stock(prices, name, timesteps_per_period, volatility)
     Stock(;kwargs)
-    Stock(price; kwargs)
 
 Construct a Stock type to use as a base asset for FinancialInstrument.
 
@@ -213,7 +212,6 @@ end
 """
     Commodity(prices, name, timesteps_per_period, volatility)
     Commodity(;kwargs)
-    Commodity(price; kwargs)
 
 Construct a Commodity type to use as a base asset for FinancialInstrument.
 
@@ -309,7 +307,6 @@ end
 """
     Bond(prices, name, time_mat, coupon_rate)
     Bond(;kwargs)
-    Bond(price; kwargs)
 
 Construct a Bond type to use as a base asset for FinancialInstrument.
 

--- a/src/Models/pricingmodels.jl
+++ b/src/Models/pricingmodels.jl
@@ -331,8 +331,8 @@ function price!(
 
     dt = fin_obj.maturity / sim_size
     # create the data to be used in the analysis 
-    data_input = LogDiffInput(
-        sim_size;
+    data_input = LogDiffInput(;
+        nTimeStep = sim_size,
         initial = fin_obj.widget.prices[end],
         volatility = fin_obj.widget.volatility * sqrt(fin_obj.maturity),
         drift = fin_obj.risk_free_rate * fin_obj.maturity,

--- a/src/Models/pricingmodels.jl
+++ b/src/Models/pricingmodels.jl
@@ -324,8 +324,8 @@ price!(call, MonteCarlo{MCBootstrap}; bootstrap_method=CircularBlock, n_sims=10)
 function price!(
     fin_obj::Option,
     pricing_model::Type{MonteCarlo{LogDiffusion}};
-    n_sims::Int = 100,
-    sim_size::Int = 100,
+    n_sims = 100,
+    sim_size = 100,
     _...
 )
 
@@ -352,8 +352,8 @@ end
 function price!(
     fin_obj::Option,
     pricing_model::Type{MonteCarlo{MCBootstrap}};
-    bootstrap_method::Type{<:TSBootMethod} = Stationary,
-    n_sims::Int = 100,
+    bootstrap_method = Stationary,
+    n_sims = 100,
     _...
 )
     length(fin_obj.widget.prices) >= 2 ? 

--- a/src/Models/pricingmodels.jl
+++ b/src/Models/pricingmodels.jl
@@ -304,11 +304,11 @@ specified. Note: Only European Options call be priced via Monte Carlo methods.
 # Keyword arguments
 
 ## For LogDiffusion model
-- `n_sims::Int`: Number of simulations to be run. Default 100.
-- `sim_size::Int`: The number of generated steps in each simulated run. Default 100.
+- `n_sims`: Number of simulations to be run. Default 100.
+- `sim_size`: The number of generated steps in each simulated run. Default 100.
 
 ## For MCBootstrap model
-- `n_sims::Int`: Number of simulations to be run. Defualt 100
+- `n_sims`: Number of simulations to be run. Defualt 100
 - `bootstrap_method`: block bootstrap method to be used. Must be a subtype of `TSBootMethod`. Defualt=`Stationary`
 
 # Examples 

--- a/src/Models/pricingmodels.jl
+++ b/src/Models/pricingmodels.jl
@@ -24,7 +24,7 @@ price!(a_fin_inst, BinomialTree)
 ```
 """
 price!(fin_obj, pricing_model; _...) = 
-    error("Cannon price $(typeof(fin_obj)) with $(typeof(pricing_model))")
+    error("Cannot price $(typeof(fin_obj)) with $(typeof(pricing_model))")
 
 """
     price!(fin_obj::Option, pricing_model::Type{BinomialTree}; kwargs...)

--- a/src/Models/pricingmodels.jl
+++ b/src/Models/pricingmodels.jl
@@ -109,9 +109,9 @@ function price!(
     p = get_p(r, dt, u, d, delta)  # risk neutral probability of an up move
 
     # Get terminal node p*
-    a_vector = AbstractFloat[]
+    a_vector = zeros(valtype(valtype(fin_obj.values_library)), tree_depth + 1)
     for k = tree_depth:-1:0
-        push!(a_vector, max(s_0 * u^k * d^(tree_depth - k) - strike_price, 0))
+        a_vector[tree_depth-k+1] = max(s_0 * u^k * d^(tree_depth - k) - strike_price, 0)
     end
     to_return = 0
 
@@ -189,9 +189,9 @@ function price!(
     p = get_p(r, dt, u, d, delta)  # risk neutral probability of an up move
 
     # Get terminal node p*
-    a_vector = AbstractFloat[]
+    a_vector = zeros(valtype(valtype(fin_obj.values_library)), tree_depth + 1)
     for k = tree_depth:-1:0
-        push!(a_vector, max(strike_price - s_0 * u^k * d^(tree_depth - k), 0))
+        a_vector[tree_depth-k+1] = max(strike_price - s_0 * u^k * d^(tree_depth - k), 0)
     end
 
     to_return = 0

--- a/src/Models/pricingmodels.jl
+++ b/src/Models/pricingmodels.jl
@@ -23,8 +23,9 @@ a_fin_inst = EuroCallOption(a_stock, 40; risk_free_rate=.05)
 price!(a_fin_inst, BinomialTree)  
 ```
 """
-price!(fin_obj::Any, pricing_model::Type{<:Any}; _...) =
-    error("Use a FinancialObject and a Model type")
+price!(fin_obj, pricing_model; _...) = 
+    error("Cannon price $(typeof(fin_obj)) with $(typeof(pricing_model))")
+
 """
     price!(fin_obj::Option, pricing_model::Type{BinomialTree}; kwargs...)
 
@@ -47,8 +48,6 @@ a_fin_inst = EuroCallOption(a_stock, 40; risk_free_rate=.05)
 price!(a_fin_inst, BinomialTree)  
 ```
 """
-price!(fin_obj::Option, pricing_model::Type{BinomialTree}; _...) =
-    error("Something went wrong. Make sure you're using a defined Option subtype")
 
 function price!(
     fin_obj::EuroCallOption,
@@ -251,8 +250,6 @@ call = EuroCallOption(stock, 40; risk_free_rate=.08, maturity=.25)
 price!(call, BlackScholes)
 ```
 """
-price!(fin_obj::Option, pricing_model::Type{BlackScholes}; _...) =
-    error("Use a European call or put option for the Black Scholes pricing method")
 
 function price!(fin_obj::EuroCallOption{<:Widget}, pricing_model::Type{BlackScholes}; _...)
     c1 = log(fin_obj.widget.prices[end] / fin_obj.strike_price)
@@ -294,28 +291,6 @@ end
 
 
 # ----- Price models using Monte Carlo sims
-
-# error out if using an American option 
-price!(
-    fin_obj::AmericanCallOption{<:Widget},
-    pricing_model::Type{MonteCarlo{LogDiffusion}};
-    _...,
-) = error("Cannot price an American Option using Monte Carlo methods now")
-price!(
-    fin_obj::AmericanPutOption{<:Widget},
-    pricing_model::Type{MonteCarlo{LogDiffusion}};
-    _...,
-) = error("Cannot price an American Option using Monte Carlo methods now")
-price!(
-    fin_obj::AmericanCallOption{<:Widget},
-    pricing_model::Type{MonteCarlo{MCBootstrap}};
-    _...,
-) = error("Cannot price an American Option using Monte Carlo methods now")
-price!(
-    fin_obj::AmericanPutOption{<:Widget},
-    pricing_model::Type{MonteCarlo{MCBootstrap}};
-    _...,
-) = error("Cannot price an American Option using Monte Carlo methods now")
 """
     price!(fin_obj::Option, MonteCarlo{MonteCarloModel}; kwargs...)
 

--- a/src/Models/pricingmodels.jl
+++ b/src/Models/pricingmodels.jl
@@ -375,7 +375,7 @@ function price!(
 
 
     data_input =
-        BootstrapInput{bootstrap_method}(; input_data=returns, 
+        BootstrapInput(returns, bootstrap_method; 
             n=fin_obj.widget.timesteps_per_period - 1
         )
     data = makedata(data_input, n_sims)

--- a/test/bootstraptests.jl
+++ b/test/bootstraptests.jl
@@ -16,7 +16,7 @@
     beta = top / bottom
 
     # check a set of bootstraps to see if we can recover beta
-    input = BootstrapInput(ar1, v; n=1000)
+    input = BootstrapInput(ar1, v; n=1000,block_size=50)
     results = zeros(1000)
     for i = 1:1000
         bootstrap = makedata(input)

--- a/test/bootstraptests.jl
+++ b/test/bootstraptests.jl
@@ -16,7 +16,7 @@
     beta = top / bottom
 
     # check a set of bootstraps to see if we can recover beta
-    input = BootstrapInput{v}(ar1, 1000, 50)
+    input = BootstrapInput(ar1, v; n=1000)
     results = zeros(1000)
     for i = 1:1000
         bootstrap = makedata(input)
@@ -39,7 +39,7 @@ end
     @test ar1ADF.stat < ar1ADF.cv[1]
 
     # bootstrap AR(1) series 
-    input = BootstrapInput{Stationary}(ar1, 1000, 50)
+    input = BootstrapInput(ar1, Stationary; n=10000)
     bs_data = makedata(input)
     bootstrap = [bs_data[i] for i = 1:length(bs_data)]
     bsADF = ADFTest(bootstrap, :none, 0)
@@ -148,7 +148,7 @@ end
 ]
     n = 10 # number of rows (resample size) in the resulting matrix
     m = 4 # number of columns (runs) in resulting matrix
-    bs_input = BootstrapInput{bstype}([1, 2, 3, 4, 5, 6, 7, 8], n, 3)
+    bs_input = BootstrapInput([1, 2, 3, 4, 5, 6, 7, 8], bstype; n=n, block_size=3)
     @test size(makedata(bs_input, m)) == (n, m)
 end
 

--- a/test/datagentests.jl
+++ b/test/datagentests.jl
@@ -1,39 +1,43 @@
 # test data gen type constructor 
 @testset verbose = true "input type constructor tests" begin
     @testset "test kwargs for $v" for v in (Stationary, MovingBlock, CircularBlock)
-        kwargs = Dict(:input_data => [1, 2, 3, 4, 5], :n => 10, :block_size => 4)
-        input = BootstrapInput{v}(; kwargs...)
+        kwargs = Dict(:n => 10, :block_size => 4)
+        input = BootstrapInput([1, 2, 3, 4, 5], v; kwargs...)
         @test input.input_data == [1, 2, 3, 4, 5]
         @test input.n == 10
         @test input.block_size == 4
     end
 
     @testset "test for correct type" begin
-        kwargs = Dict(:input_data => [1, 2, 3, 4, 5], :n => 10, :block_size => 4)
-        input1 = BootstrapInput{MovingBlock}(; kwargs...)
-        input2 = BootstrapInput{CircularBlock}(; kwargs...)
-        input3 = BootstrapInput{Stationary}(; kwargs...)
-        @test isa(input1, BootstrapInput{MovingBlock})
-        @test isa(input2, BootstrapInput{CircularBlock})
-        @test isa(input3, BootstrapInput{Stationary})
+        input_data = [1, 2, 3, 4, 5]
+        kwargs = Dict(:n => 10, :block_size => 4.0)
+        input1 = BootstrapInput(input_data, MovingBlock; kwargs...)
+        input2 = BootstrapInput(input_data, CircularBlock; kwargs...)
+        input3 = BootstrapInput(input_data, Stationary; kwargs...)
+        @test isa(input1, BootstrapInput{MovingBlock,Int64,Float64,Int64})
+        @test isa(input2, BootstrapInput{CircularBlock,Int64,Float64,Int64})
+        @test isa(input3, BootstrapInput{Stationary,Int64,Float64,Int64})
     end
 
     @testset "Test constructor limits for $v" for v in
                                                   (MovingBlock, CircularBlock, Stationary)
         # test for size of input_data
-        @test_throws ErrorException BootstrapInput{v}(;
-            input_data = [1],
+        @test_throws ErrorException BootstrapInput(
+            [1],
+            v;
             n = 10,
             block_size = 1,
         )
         # test constraint for block_size
-        @test_throws ErrorException BootstrapInput{v}(;
-            input_data = [1, 2, 3],
+        @test_throws ErrorException BootstrapInput(
+            [1, 2, 3],
+            v;
             n = 10,
             block_size = 5,
         )
-        @test_throws ErrorException BootstrapInput{v}(;
-            input_data = [1, 2, 3],
+        @test_throws ErrorException BootstrapInput(
+            [1, 2, 3],
+            v;
             n = 0,
             block_size = 2,
         )

--- a/test/fininsttests.jl
+++ b/test/fininsttests.jl
@@ -21,7 +21,7 @@
         @test test_fininst.maturity == 0.5
         @test test_fininst.risk_free_rate == 0.08
         @test test_fininst.label == "test"
-        @test test_fininst.values_library == Dict{String,Dict{String,AbstractFloat}}()
+        @test test_fininst.values_library == Dict{String,Dict{String,Float64}}()
     end
 
     @testset "Only widget and strike_price constructor for $fininst" for fininst in [
@@ -36,7 +36,7 @@
         @test test_fininst.maturity == 1.0
         @test test_fininst.risk_free_rate == 0.02
         @test test_fininst.label == ""
-        @test test_fininst.values_library == Dict{String,Dict{String,AbstractFloat}}()
+        @test test_fininst.values_library == Dict{String,Dict{String,Float64}}()
     end
     
     @testset "Constructor limits for $fininst" for fininst in [
@@ -56,7 +56,7 @@
         @test_warn "It is not recommended to pass values through the constructor. price!(Instrument, pricing_model) should be used" fininst(;
             widget = widget, 
             strike_price = 6, 
-            values_library=Dict{String, Dict{String, AbstractFloat}}("test" => Dict("test2" => 1.0)))
+            values_library=Dict{String, Dict{String, Float64}}("test" => Dict("test2" => 1.0)))
     end
 end
 

--- a/test/fininsttests.jl
+++ b/test/fininsttests.jl
@@ -51,11 +51,11 @@
         # check for negative strike price
         @test_throws ErrorException fininst(widget, -1)
         # check for negative maturity
-        @test_throws ErrorException fininst(widget, 6; maturity=-1)
+        @test_throws ErrorException fininst(;widget = widget, strike_price = 6, maturity=-1)
         # check for warning of giving constructor prefilled dictionary
-        @test_warn "It is not recommended to pass values through the constructor. price!(Instrument, pricing_model) should be used" fininst(
-            widget, 
-            6; 
+        @test_warn "It is not recommended to pass values through the constructor. price!(Instrument, pricing_model) should be used" fininst(;
+            widget = widget, 
+            strike_price = 6, 
             values_library=Dict{String, Dict{String, AbstractFloat}}("test" => Dict("test2" => 1.0)))
     end
 end

--- a/test/hedgingtests.jl
+++ b/test/hedgingtests.jl
@@ -327,7 +327,7 @@ end
             BlackScholes,
             Naked,
             future_prices,
-            10,
+            10.0,
             252;
             transaction_cost = 0.0
         )
@@ -349,9 +349,9 @@ end
             future_prices,
             10,
             252, 
-            10, 
-            2, 
-            3;
+            10.0, 
+            2.0, 
+            3.0;
             transaction_cost = 0.0
         )
 
@@ -367,9 +367,9 @@ end
             future_prices,
             10,
             252, 
-            10, 
-            0, 
-            0,
+            10.0, 
+            0.0, 
+            0.0,
             .08;
             transaction_cost = 0.0
         )
@@ -383,10 +383,10 @@ end
             future_prices,
             10,
             252, 
-            30, 
-            0, 
-            0,
-            0,
+            30.0, 
+            0.0, 
+            0.0,
+            0.0,
             .08;
             transaction_cost = 0.0
         )
@@ -404,7 +404,7 @@ end
             kwargs...
         )
             if step == 1
-                buy(fin_obj, 2, holdings, pricing_model)
+                buy(fin_obj, 2.0, holdings, pricing_model)
             end
 
             if step == 4
@@ -453,8 +453,8 @@ end
             "stock2" => [67, 74, 73, 67, 67, 75, 69, 71, 69, 70]
         )
         objs = [test_call, test_call2]
-        fin_obj_count = Dict("call" => 1.0, "call2" => 2)
-        widget_count = Dict("stock" => 2.0, "stock2" => 3)
+        fin_obj_count = Dict("call" => 1.0, "call2" => 2.0)
+        widget_count = Dict("stock" => 2.0, "stock2" => 3.0)
 
         test_ret, ts_holdings, obj_array = strategy_returns(
             objs, 
@@ -463,7 +463,7 @@ end
             future_prices,
             10,
             252,
-            0,
+            0.0,
             fin_obj_count,
             widget_count
         )

--- a/test/hedgingtests.jl
+++ b/test/hedgingtests.jl
@@ -266,7 +266,7 @@ end
    @testset "single fininst method" begin
         test_stock = Stock(; prices=[99, 97, 90, 83, 83, 88, 88, 89, 97, 100], name="stock", timesteps_per_period=252)
         test_call = EuroCallOption(;widget=test_stock, strike_price=110, maturity=.5, label="call", risk_free_rate=.02)
-        holdings = Dict{String, AbstractFloat}(
+        holdings = Dict{String, Float64}(
             "cash" => 0,
             "stock" => 2,
             "call" => -1
@@ -289,7 +289,7 @@ end
         
         obj_array = [test_call, test_put, test_call2] # doesn't have test_put2
         widget_dict = Dict("stock" => test_stock, "stock2" => test_stock2) # doesnt' have stock3
-        holdings = Dict{String, AbstractFloat}(
+        holdings = Dict{String, Float64}(
             "cash" => 0,
             "stock" => 1, 
             "stock2" => -2, 

--- a/test/hedgingtests.jl
+++ b/test/hedgingtests.jl
@@ -5,7 +5,7 @@ using Logging
     
 @testset "buy function tests" begin
     @testset "buy without transaction costs" begin
-        test_stock = Stock(41; name = "test", volatility = 0.3)  
+        test_stock = Stock(41.0; name = "test", volatility = 0.3)  
         test_call = EuroCallOption(test_stock, 40; label = "test_call", risk_free_rate = 0.08, maturity = 0.25)
         # the price!() of this call should be 3.399 (see pricingmodel tests)
         holdings = Dict("cash" => 10.0, "test_call" => 1, "test" => 1)
@@ -25,7 +25,7 @@ using Logging
     end
 
     @testset "buy with transaction_costs" begin
-        test_stock = Stock(41; name = "test", volatility = 0.3)  
+        test_stock = Stock(41.0; name = "test", volatility = 0.3)  
         test_call = EuroCallOption(test_stock, 40; label = "test_call", risk_free_rate = 0.08, maturity = 0.25)
         # the price!() of this call should be 3.399 (see pricingmodel tests)
         holdings = Dict("cash" => 10.0, "test_call" => 1, "test" => 1)
@@ -45,7 +45,7 @@ using Logging
     end
 
     @testset "buy function limitations" begin
-        test_stock = Stock(41; name = "test", volatility = 0.3)  
+        test_stock = Stock(41.0; name = "test", volatility = 0.3)  
         test_call = EuroCallOption(test_stock, 40; label = "test_call", risk_free_rate = 0.08, maturity = 0.25)
         holdings = Dict("cash" => 10.0, "test_call" => 1, "test" => 1)
         # buying negative widget
@@ -63,7 +63,7 @@ end
 
 @testset "sell function tests" begin
     @testset "sell without transaction costs" begin
-        test_stock = Stock(41; name = "test", volatility = 0.3)  
+        test_stock = Stock(41.0; name = "test", volatility = 0.3)  
         test_call = EuroCallOption(test_stock, 40; label = "test_call", risk_free_rate = 0.08, maturity = 0.25)
         # the price!() of this call should be 3.399 (see pricingmodel tests)
         holdings = Dict("cash" => 10.0, "test_call" => 1, "test" => 1)
@@ -83,7 +83,7 @@ end
     end
 
     @testset "sell with transaction_costs" begin
-        test_stock = Stock(41; name = "test", volatility = 0.3)  
+        test_stock = Stock(41.0; name = "test", volatility = 0.3)  
         test_call = EuroCallOption(test_stock, 40; label = "test_call", risk_free_rate = 0.08, maturity = 0.25)
         # the price!() of this call should be 3.399 (see pricingmodel tests)
         holdings = Dict("cash" => 10.0, "test_call" => 1, "test" => 1)
@@ -103,7 +103,7 @@ end
     end
 
     @testset "sell function limitations" begin
-        test_stock = Stock(41; name = "test", volatility = 0.3)  
+        test_stock = Stock(41.0; name = "test", volatility = 0.3)  
         test_call = EuroCallOption(test_stock, 40; label = "test_call", risk_free_rate = 0.08, maturity = 0.25)
         holdings = Dict("cash" => 10.0, "test_call" => 1, "test" => 1)
         # sell negative widget
@@ -530,9 +530,6 @@ end
             fin_obj_count,
             widget_count
         )
-
-        
-        
     end
 end
 end # master hedging/ strategy testset 

--- a/test/hedgingtests.jl
+++ b/test/hedgingtests.jl
@@ -6,7 +6,7 @@ using Logging
 @testset "buy function tests" begin
     @testset "buy without transaction costs" begin
         test_stock = Stock(41.0; name = "test", volatility = 0.3)  
-        test_call = EuroCallOption(test_stock, 40; label = "test_call", risk_free_rate = 0.08, maturity = 0.25)
+        test_call = EuroCallOption(;widget = test_stock, strike_price = 40, label = "test_call", risk_free_rate = 0.08, maturity = 0.25)
         # the price!() of this call should be 3.399 (see pricingmodel tests)
         holdings = Dict("cash" => 10.0, "test_call" => 1, "test" => 1)
         # buy call without transaction costs
@@ -26,7 +26,7 @@ using Logging
 
     @testset "buy with transaction_costs" begin
         test_stock = Stock(41.0; name = "test", volatility = 0.3)  
-        test_call = EuroCallOption(test_stock, 40; label = "test_call", risk_free_rate = 0.08, maturity = 0.25)
+        test_call = EuroCallOption(;widget = test_stock, strike_price = 40, label = "test_call", risk_free_rate = 0.08, maturity = 0.25)
         # the price!() of this call should be 3.399 (see pricingmodel tests)
         holdings = Dict("cash" => 10.0, "test_call" => 1, "test" => 1)
         # buy call without transaction costs
@@ -46,7 +46,7 @@ using Logging
 
     @testset "buy function limitations" begin
         test_stock = Stock(41.0; name = "test", volatility = 0.3)  
-        test_call = EuroCallOption(test_stock, 40; label = "test_call", risk_free_rate = 0.08, maturity = 0.25)
+        test_call = EuroCallOption(;widget = test_stock, strike_price = 40, label = "test_call", risk_free_rate = 0.08, maturity = 0.25)
         holdings = Dict("cash" => 10.0, "test_call" => 1, "test" => 1)
         # buying negative widget
         @test_logs (:warn,"unable to buy negative amounts. Use sell instead") buy(test_stock, -1, holdings, BlackScholes)
@@ -56,7 +56,7 @@ using Logging
         @test_logs (:warn,"unable to buy negative amounts. Use sell instead") buy(test_call, -1, holdings, BlackScholes, 1)
 
         # buying expired FinancialInstrument
-        expired_call = EuroCallOption(test_stock, 40; label = "test_call", risk_free_rate = 0.08, maturity = 0.0)
+        expired_call = EuroCallOption(;widget = test_stock, strike_price = 40, label = "test_call", risk_free_rate = 0.08, maturity = 0.0)
         @test_logs (:warn, "unable to buy expired FinancialInstrument") buy(expired_call, 1, holdings, BlackScholes, 1)
     end
 end
@@ -64,7 +64,7 @@ end
 @testset "sell function tests" begin
     @testset "sell without transaction costs" begin
         test_stock = Stock(41.0; name = "test", volatility = 0.3)  
-        test_call = EuroCallOption(test_stock, 40; label = "test_call", risk_free_rate = 0.08, maturity = 0.25)
+        test_call = EuroCallOption(;widget = test_stock, strike_price = 40, label = "test_call", risk_free_rate = 0.08, maturity = 0.25)
         # the price!() of this call should be 3.399 (see pricingmodel tests)
         holdings = Dict("cash" => 10.0, "test_call" => 1, "test" => 1)
         # sell call without transaction costs
@@ -84,7 +84,7 @@ end
 
     @testset "sell with transaction_costs" begin
         test_stock = Stock(41.0; name = "test", volatility = 0.3)  
-        test_call = EuroCallOption(test_stock, 40; label = "test_call", risk_free_rate = 0.08, maturity = 0.25)
+        test_call = EuroCallOption(;widget = test_stock, strike_price = 40, label = "test_call", risk_free_rate = 0.08, maturity = 0.25)
         # the price!() of this call should be 3.399 (see pricingmodel tests)
         holdings = Dict("cash" => 10.0, "test_call" => 1, "test" => 1)
         # sell call without transaction costs
@@ -104,7 +104,7 @@ end
 
     @testset "sell function limitations" begin
         test_stock = Stock(41.0; name = "test", volatility = 0.3)  
-        test_call = EuroCallOption(test_stock, 40; label = "test_call", risk_free_rate = 0.08, maturity = 0.25)
+        test_call = EuroCallOption(;widget = test_stock, strike_price = 40, label = "test_call", risk_free_rate = 0.08, maturity = 0.25)
         holdings = Dict("cash" => 10.0, "test_call" => 1, "test" => 1)
         # sell negative widget
         @test_logs (:warn,"unable to sell negative amounts. Use buy instead") sell(test_stock, -1, holdings, BlackScholes)
@@ -114,7 +114,7 @@ end
         @test_logs (:warn,"unable to sell negative amounts. Use buy instead") sell(test_call, -1, holdings, BlackScholes, 1)
 
         # sell expired FinancialInstrument
-        expired_call = EuroCallOption(test_stock, 40; label = "test_call", risk_free_rate = 0.08, maturity = 0.0)
+        expired_call = EuroCallOption(;widget = test_stock, strike_price = 40, label = "test_call", risk_free_rate = 0.08, maturity = 0.0)
         @test_logs (:warn, "unable to sell expired FinancialInstrument") sell(expired_call, 1, holdings, BlackScholes, 1)
     end
 end
@@ -122,7 +122,7 @@ end
 @testset verbose=true "update_obj tests" begin
     @testset "single update_obj tests" begin
         test_stock = Stock(; prices=[99, 97, 90, 83, 83, 88, 88, 89, 97, 100], name="stock", timesteps_per_period=252)
-        test_call = EuroCallOption(test_stock, 110; maturity=.5, label="call", risk_free_rate=.02)
+        test_call = EuroCallOption(;widget = test_stock, strike_price = 110, maturity=.5, label="call", risk_free_rate=.02)
         future_prices = [1, 2, 3]
         holdings = Dict("cash" => 0.0, "stock" => 1.0, "call" => 1.0)
         new_call = update_obj(
@@ -149,7 +149,7 @@ end
         @test new_call.risk_free_rate == .02
         
         # test for expiring object
-        exp_call = EuroCallOption(test_stock, 1; maturity=.001, label="exp_call", risk_free_rate=.02)
+        exp_call = EuroCallOption(;widget = test_stock, strike_price = 1, maturity=.001, label="exp_call", risk_free_rate=.02)
         holdings["exp_call"] = 1
         @test_logs (:warn, "exp_call has expired, it will not be able to be bought or sold") update_obj(
             exp_call,
@@ -166,7 +166,7 @@ end
         @test holdings["cash"] == 1
         
         # test that it doesn't warn on already expired fin obj 
-        exp_call = EuroCallOption(test_stock, 1; maturity=0, label="exp_call", risk_free_rate=.02)
+        exp_call = EuroCallOption(;widget = test_stock, strike_price = 1, maturity=0, label="exp_call", risk_free_rate=.02)
         @test_logs min_level=Logging.Warn update_obj(
             exp_call,
             Naked, 
@@ -182,10 +182,10 @@ end
     @testset "vector update_obj() tests" begin
         test_stock = Stock(; prices=[99, 97, 90, 83, 83, 88, 88, 89, 97, 100], name="stock", timesteps_per_period=252)
         test_stock2 = Stock(; prices=[66, 61, 70, 55, 65, 63, 57, 55, 53, 68], name="stock2", timesteps_per_period=252)
-        test_call = EuroCallOption(test_stock, 110; maturity=.5, label="call", risk_free_rate=.02)
-        test_put = EuroPutOption(test_stock, 110; maturity=.5, label="put", risk_free_rate=.02)
-        test_call2 = EuroCallOption(test_stock2, 70; maturity=1, label="call2", risk_free_rate=.02)
-        test_put2 = EuroPutOption(test_stock2, 70; maturity=0.001, label="put2", risk_free_rate=.02)
+        test_call = EuroCallOption(;widget=test_stock, strike_price=110, maturity=.5, label="call", risk_free_rate=.02)
+        test_put = EuroPutOption(;widget=test_stock, strike_price=110, maturity=.5, label="put", risk_free_rate=.02)
+        test_call2 = EuroCallOption(;widget=test_stock2, strike_price=70, maturity=1, label="call2", risk_free_rate=.02)
+        test_put2 = EuroPutOption(;widget=test_stock2, strike_price=70, maturity=0.001, label="put2", risk_free_rate=.02)
         
         obj_array = [test_call, test_put, test_call2]
         obj_array2 = [test_put2] # one that should throw a warning
@@ -246,7 +246,7 @@ end
         @test holdings["cash"] == 65
 
         # test that doesn't throw warning a second time (if holdings != 0)
-        test_put2 = EuroPutOption(test_stock2, 70; maturity=0, label="put2", risk_free_rate=.02)
+        test_put2 = EuroPutOption(;widget=test_stock2, strike_price=70, maturity=0, label="put2", risk_free_rate=.02)
         obj_array2 = [test_put2]
         @test_logs min_level=Logging.Warn update_obj(
             obj_array2, 
@@ -265,7 +265,7 @@ end
 @testset verbose=true "unwind tests" begin
    @testset "single fininst method" begin
         test_stock = Stock(; prices=[99, 97, 90, 83, 83, 88, 88, 89, 97, 100], name="stock", timesteps_per_period=252)
-        test_call = EuroCallOption(test_stock, 110; maturity=.5, label="call", risk_free_rate=.02)
+        test_call = EuroCallOption(;widget=test_stock, strike_price=110, maturity=.5, label="call", risk_free_rate=.02)
         holdings = Dict{String, AbstractFloat}(
             "cash" => 0,
             "stock" => 2,
@@ -282,10 +282,10 @@ end
         test_stock = Stock(; prices=[99, 97, 90, 83, 83, 88, 88, 89, 97, 100], name="stock", timesteps_per_period=252)
         test_stock2 = Stock(; prices=[66, 61, 70, 55, 65, 63, 57, 55, 53, 68], name="stock2", timesteps_per_period=252)
         test_stock3 = Stock(; prices=[66, 61, 70, 55, 65, 63, 57, 55, 53, 68], name="stock3", timesteps_per_period=252)
-        test_call = EuroCallOption(test_stock, 110; maturity=.5, label="call", risk_free_rate=.02)
-        test_put = EuroPutOption(test_stock, 110; maturity=.5, label="put", risk_free_rate=.02)
-        test_call2 = EuroCallOption(test_stock2, 70; maturity=1, label="call2", risk_free_rate=.02)
-        test_put2 = EuroPutOption(test_stock2, 70; maturity=0.001, label="put2", risk_free_rate=.02)
+        test_call = EuroCallOption(;widget=test_stock, strike_price=110, maturity=.5, label="call", risk_free_rate=.02)
+        test_put = EuroPutOption(;widget=test_stock, strike_price=110, maturity=.5, label="put", risk_free_rate=.02)
+        test_call2 = EuroCallOption(;widget=test_stock2, strike_price=70, maturity=1, label="call2", risk_free_rate=.02)
+        test_put2 = EuroPutOption(;widget=test_stock2, strike_price=70, maturity=0.001, label="put2", risk_free_rate=.02)
         
         obj_array = [test_call, test_put, test_call2] # doesn't have test_put2
         widget_dict = Dict("stock" => test_stock, "stock2" => test_stock2) # doesnt' have stock3
@@ -318,7 +318,7 @@ end
 @testset verbose=true "strategy_returns tests" begin
     @testset "single strategy_returns tests" begin
         test_stock = Stock(; prices=[99, 97, 90, 83, 83, 88, 88, 89, 97, 100], name="stock", timesteps_per_period=252)
-        test_call = EuroCallOption(test_stock, 110; maturity=.5, label="call", risk_free_rate=.02)
+        test_call = EuroCallOption(;widget=test_stock, strike_price=110, maturity=.5, label="call", risk_free_rate=.02)
         future_prices = [100, 104, 109, 105, 108, 108, 101, 101, 104, 110]
 
         # with default values
@@ -446,8 +446,8 @@ end
     @testset "vector/ multi strategy_returns tests" begin
         test_stock = Stock(; prices=[99, 97, 90, 83, 83, 88, 88, 89, 97, 100], name="stock", timesteps_per_period=252)
         test_stock2 = Stock(; prices=[66, 61, 70, 55, 65, 63, 57, 55, 53, 68], name="stock2", timesteps_per_period=252)
-        test_call = EuroCallOption(test_stock, 110; maturity=.5, label="call", risk_free_rate=.02)
-        test_call2 = EuroCallOption(test_stock2, 70; maturity=1, label="call2", risk_free_rate=.02)
+        test_call = EuroCallOption(;widget=test_stock, strike_price=110, maturity=.5, label="call", risk_free_rate=.02)
+        test_call2 = EuroCallOption(;widget=test_stock2, strike_price=70, maturity=1, label="call2", risk_free_rate=.02)
         future_prices = Dict(
             "stock" => [100, 104, 109, 105, 108, 108, 101, 101, 104, 110],
             "stock2" => [67, 74, 73, 67, 67, 75, 69, 71, 69, 70]

--- a/test/pricingmodeltests.jl
+++ b/test/pricingmodeltests.jl
@@ -17,7 +17,7 @@ using Random
     The Value of this call option should be 7.074
     """
     # Create needed values
-    a_stock = Stock(41; volatility = 0.3)  # create a widget
+    a_stock = Stock(41.0; volatility = 0.3)  # create a widget
     a_fin_inst = EuroCallOption(a_stock, 40; risk_free_rate = 0.08) # create an Option
     price!(a_fin_inst, BinomialTree)  # add the binomial Option value to the options values
 
@@ -45,7 +45,7 @@ end
     The Value of this call option should be 7.074
     """
     # Create needed values
-    a_stock = Stock(41; volatility = 0.3)  # create a widget
+    a_stock = Stock(41.0; volatility = 0.3)  # create a widget
     a_fin_inst = EuroPutOption(a_stock, 40; risk_free_rate = 0.08)  # create an Option
     price!(a_fin_inst, BinomialTree)  # add the binomial Option value to the options values
 
@@ -72,7 +72,7 @@ end
     The Value of this call option should be 7.074
     """
     # Create needed values
-    a_stock = Stock(41; volatility = 0.3)  # create a widget
+    a_stock = Stock(41.0; volatility = 0.3)  # create a widget
     a_fin_inst = AmericanPutOption(a_stock, 40; risk_free_rate = 0.08)  # create an Option
     price!(a_fin_inst, BinomialTree)  # add the binomial Option value to the options values
 
@@ -99,7 +99,7 @@ end
     The Value of this call option should be 7.074
     """
     # Create needed values
-    a_stock = Stock(110; volatility = 0.3)  # create a widget
+    a_stock = Stock(110.0; volatility = 0.3)  # create a widget
     a_fin_inst = AmericanCallOption(a_stock, 100; risk_free_rate = 0.05)  # create an Option
     price!(a_fin_inst, BinomialTree; delta = 0.035)  # add the binomial Option value to the options values
 
@@ -126,7 +126,7 @@ end # test for BinomialTree
         The call option value should be 3.399
         """
         # create underlying stock and the needed call option
-        stock = Stock(41; volatility = 0.3)
+        stock = Stock(41.0; volatility = 0.3)
         call = EuroCallOption(stock, 40; risk_free_rate = 0.08, maturity = 0.25)
         price!(call, BlackScholes)
 
@@ -145,7 +145,7 @@ end # test for BinomialTree
         The put option value should be 1.607
         """
         # create underlying stock and the needed call option
-        stock = Stock(41; volatility = 0.3)
+        stock = Stock(41.0; volatility = 0.3)
         put = EuroPutOption(stock, 40; risk_free_rate = 0.08, maturity = 0.25)
         price!(put, BlackScholes)
 

--- a/test/pricingmodeltests.jl
+++ b/test/pricingmodeltests.jl
@@ -18,7 +18,7 @@ using Random
     """
     # Create needed values
     a_stock = Stock(41.0; volatility = 0.3)  # create a widget
-    a_fin_inst = EuroCallOption(a_stock, 40; risk_free_rate = 0.08) # create an Option
+    a_fin_inst = EuroCallOption(;widget = a_stock, strike_price = 40, risk_free_rate = 0.08) # create an Option
     price!(a_fin_inst, BinomialTree)  # add the binomial Option value to the options values
 
     # check that a value was added to a_fin_inst
@@ -46,7 +46,7 @@ end
     """
     # Create needed values
     a_stock = Stock(41.0; volatility = 0.3)  # create a widget
-    a_fin_inst = EuroPutOption(a_stock, 40; risk_free_rate = 0.08)  # create an Option
+    a_fin_inst = EuroPutOption(;widget = a_stock, strike_price = 40, risk_free_rate = 0.08)  # create an Option
     price!(a_fin_inst, BinomialTree)  # add the binomial Option value to the options values
 
     # check that a value was added to a_fin_inst
@@ -73,7 +73,7 @@ end
     """
     # Create needed values
     a_stock = Stock(41.0; volatility = 0.3)  # create a widget
-    a_fin_inst = AmericanPutOption(a_stock, 40; risk_free_rate = 0.08)  # create an Option
+    a_fin_inst = AmericanPutOption(;widget = a_stock, strike_price = 40, risk_free_rate = 0.08)  # create an Option
     price!(a_fin_inst, BinomialTree)  # add the binomial Option value to the options values
 
     # check that a value was added to a_fin_inst
@@ -100,7 +100,7 @@ end
     """
     # Create needed values
     a_stock = Stock(110.0; volatility = 0.3)  # create a widget
-    a_fin_inst = AmericanCallOption(a_stock, 100; risk_free_rate = 0.05)  # create an Option
+    a_fin_inst = AmericanCallOption(;widget = a_stock, strike_price = 100, risk_free_rate = 0.05)  # create an Option
     price!(a_fin_inst, BinomialTree; delta = 0.035)  # add the binomial Option value to the options values
 
     # check that a value was added to a_fin_inst
@@ -127,7 +127,7 @@ end # test for BinomialTree
         """
         # create underlying stock and the needed call option
         stock = Stock(41.0; volatility = 0.3)
-        call = EuroCallOption(stock, 40; risk_free_rate = 0.08, maturity = 0.25)
+        call = EuroCallOption(;widget = stock, strike_price = 40, risk_free_rate = 0.08, maturity = 0.25)
         price!(call, BlackScholes)
 
         @test isapprox(call.values_library["BlackScholes"]["value"], 3.399; atol = 0.01)
@@ -146,7 +146,7 @@ end # test for BinomialTree
         """
         # create underlying stock and the needed call option
         stock = Stock(41.0; volatility = 0.3)
-        put = EuroPutOption(stock, 40; risk_free_rate = 0.08, maturity = 0.25)
+        put = EuroPutOption(;widget = stock, strike_price = 40, risk_free_rate = 0.08, maturity = 0.25)
         price!(put, BlackScholes)
 
         @test isapprox(put.values_library["BlackScholes"]["value"], 1.607; atol = 0.01)
@@ -160,7 +160,7 @@ end
     @testset "LogDiffusion price test" begin
         Random.seed!(78)
         test_stock = Stock(100.0; volatility = .3)
-        test_call = EuroCallOption(test_stock, 110.0; maturity=.5, risk_free_rate=.02)
+        test_call = EuroCallOption(;widget = test_stock, strike_price = 110.0, maturity=.5, risk_free_rate=.02)
 
         # testing with a simulation that ends with all paths out of the money
         @test price!(test_call, MonteCarlo{LogDiffusion}; sim_size=10, n_sims=3) == 0.0
@@ -175,7 +175,7 @@ end
     @testset "MCBootstrap price tests" begin
         Random.seed!(78)
         test_stock = Stock([99, 97, 90, 83, 83, 88, 88, 89, 97, 100])
-        test_call = EuroCallOption(test_stock, 110; maturity=.5, risk_free_rate=.02)
+        test_call = EuroCallOption(;widget = test_stock, strike_price = 110, maturity=.5, risk_free_rate=.02)
 
         @test isapprox(
             price!(test_call, MonteCarlo{MCBootstrap}; bootstrap_method=CircularBlock, n_sims=3),

--- a/test/pricingmodeltests.jl
+++ b/test/pricingmodeltests.jl
@@ -159,8 +159,8 @@ end
 
     @testset "LogDiffusion price test" begin
         Random.seed!(78)
-        test_stock = Stock(100; volatility = .3)
-        test_call = EuroCallOption(test_stock, 110; maturity=.5, risk_free_rate=.02)
+        test_stock = Stock(100.0; volatility = .3)
+        test_call = EuroCallOption(test_stock, 110.0; maturity=.5, risk_free_rate=.02)
 
         # testing with a simulation that ends with all paths out of the money
         @test price!(test_call, MonteCarlo{LogDiffusion}; sim_size=10, n_sims=3) == 0.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ include("fininsttests.jl")
 
 include("datagentests.jl")
 include("bootstraptests.jl")
-include("factorytest.jl")
+#include("factorytest.jl")
 
 include("pricingmodeltests.jl")
 

--- a/test/widgettests.jl
+++ b/test/widgettests.jl
@@ -6,14 +6,14 @@ import InteractiveUtils
         @testset "Stock Creation" begin
             # Test the stock widget creation
             # Test ordered argumentes when only price given
-            a_widget = Stock([1, 2, 3, 4, 5, 4, 3, 2, 1])
+            a_widget = Stock(Float64[1, 2, 3, 4, 5, 4, 3, 2, 1])
             @test isapprox(a_widget.volatility, 1.322, atol = 0.001)
             @test a_widget.name == ""
             @test a_widget.prices == [1, 2, 3, 4, 5, 4, 3, 2, 1]
             @test a_widget.timesteps_per_period == 9 # tests defualt value
 
             # Test ordered argumentes when name and timesteps not given
-            a_widget = Stock(prices = [1, 2, 3, 4, 5, 4, 3, 2, 1], volatility = 0.05)
+            a_widget = Stock(prices = Float64[1, 2, 3, 4, 5, 4, 3, 2, 1], volatility = 0.05)
             @test a_widget.volatility == 0.05
             @test a_widget.name == ""
             @test a_widget.prices == [1, 2, 3, 4, 5, 4, 3, 2, 1]
@@ -21,7 +21,7 @@ import InteractiveUtils
 
             # Test ordered argumentes when all given
             a_widget = Stock(
-                prices = [1, 2, 3, 4, 5, 4, 3, 2, 1],
+                prices = Float64[1, 2, 3, 4, 5, 4, 3, 2, 1],
                 volatility = 0.05,
                 name = "Example",
                 timesteps_per_period = 9
@@ -33,7 +33,7 @@ import InteractiveUtils
 
             # Test strickly ordered inputs
             a_widget = Stock(
-                [1, 2, 3, 4, 5, 4, 3, 2, 1], 
+                Float64[1, 2, 3, 4, 5, 4, 3, 2, 1], 
                 "Example", 
                 9, 
                 0.05
@@ -110,7 +110,7 @@ import InteractiveUtils
 
     @testset "Single price creation $widget" for widget in [Stock, Commodity]
 
-        a_widget = widget(10; volatility = 0.3)
+        a_widget = widget(10.0; volatility = 0.3)
         @test a_widget.prices == [10]
         @test a_widget.volatility == 0.3
         @test a_widget.name == "" 
@@ -121,14 +121,14 @@ import InteractiveUtils
     @testset "Kwargs creation tests $widget" for widget in widget_subs
 
         # Test kwarg creation when only prices is given
-        kwargs = Dict(:prices => [1, 2, 3, 4, 5, 4, 3, 2, 1])
+        kwargs = Dict(:prices => Float64[1, 2, 3, 4, 5, 4, 3, 2, 1])
         a_widget = widget(; kwargs...)
         fields = [p for p in fieldnames(typeof(a_widget))]
         iter = Dict(fields .=> getfield.(Ref(a_widget), fields))
         @test length(findall(Base.isempty, iter)) == 1  # Test all fields in each widget have been filled in. Name defaults to "" and counts as isempty
 
         # Test kwarg creation when price and name given
-        kwargs = Dict(:prices => [1, 2, 3, 4, 5, 4, 3, 2, 1], :name => "Example")
+        kwargs = Dict(:prices => Float64[1, 2, 3, 4, 5, 4, 3, 2, 1], :name => "Example")
         a_widget = widget(; kwargs...)
         fields = [p for p in fieldnames(typeof(a_widget))]
         iter = Dict(fields .=> getfield.(Ref(a_widget), fields))
@@ -136,7 +136,7 @@ import InteractiveUtils
 
         # Test kwarg creation when obstructing feilds provided
         kwargs = Dict(
-            :prices => [1, 2, 3, 4, 5, 4, 3, 2, 1],
+            :prices => Float64[1, 2, 3, 4, 5, 4, 3, 2, 1],
             :name => "Example",
             :time_mat => 1,
             :volatility => 0.5,
@@ -151,7 +151,7 @@ import InteractiveUtils
     @testset "Constructor limits" begin
         widget_subs = InteractiveUtils.subtypes(Widget)
         @testset "Price size for $widget" for widget in widget_subs
-            @test_throws ErrorException widget(; prices = AbstractFloat[])
+            @test_throws ErrorException widget(; prices = Float64[])
         end
 
         @testset "Single price errors for $widget" for widget in [Stock, Commodity]
@@ -160,14 +160,14 @@ import InteractiveUtils
             # using kwargs must give volatility
             @test_throws ErrorException widget(; prices = 1)
             # using position args price > 0
-            @test_throws ErrorException widget(-1, "", 0.03)
+            @test_throws ErrorException widget{Int64,Int64,Float64}(-1, "", 0.03)
             # using position must give volatility
-            @test_throws ErrorException widget(1, "")
+            @test_throws ErrorException widget{Int64,Int64,Float64}(1, "")
         end
 
         @testset "volatility errors for $widget" for widget in [Stock, Commodity]
-            @test_throws ErrorException widget(; prices = [1, 2, 3], volatility = -1)
-            @test_throws ErrorException widget(; prices = [1, 2, 3], volatility = nothing)
+            @test_throws ErrorException widget(; prices = Float64[1, 2, 3], volatility = -1)
+            @test_throws ErrorException widget(; prices = Float64[1, 2, 3], volatility = nothing)
         end
 
         @testset "timesteps_per_period error for $widget" for widget in [Stock, Commodity]


### PR DESCRIPTION
fixes #68 
- Changed price!() error functions to be one function to catch any combinations of `FinancialInstrument` and `Model` that aren't currently implemented. 

fixes #67 
- Changed all structs to not use abstract types as fields:
  - Changed all base assets to be parametric types based on the prices array (e.g. `Stock{Float64}`)
  - Changed `FinancialInstrument` fields to be `Int64` or `Float64` since that is not using much more memory than using `Float32` or Float16
  - Changed `LogDiffInput` to use `Int64` and `Float64`
  
These changes did cause problems when using the `factory()` functions with integer numbers such as using it with `Stock{Int64}`. So (for now) I commented out the `factory()` tests. I thought this would be ok since `factory()` is still a bit of a WIP  and is not at all type stable. Also, it's not included in the documentation pages. 