### PR TITLE
Method type annotation fixes

### DIFF
--- a/src/DataGeneration/DataGeneration.jl
+++ b/src/DataGeneration/DataGeneration.jl
@@ -46,7 +46,7 @@ input2 = BootstrapInput(data1, Stationary; n=100);
 data2 = makedata(input2, 2)
 ```
 """
-makedata(input::Any) = error("Use a DataGenInput subtype to synthesize data")
+makedata(input) = error("Use a DataGenInput subtype to synthesize data")
 
 include("logdiffusion.jl")
 include("bootstrap.jl")

--- a/src/DataGeneration/bootstrap.jl
+++ b/src/DataGeneration/bootstrap.jl
@@ -15,8 +15,8 @@ function. T can be any subtype of TSBootMethod: Stationary, MovingBlock, or Circ
 ## Keyword Arguments
 - `input_data::Array{<:Real}`: data to be resampled. Must be a 1-D array
 - `bootstrap_method`: Type of time series bootstrap to use. Must be subtype of TSBootMethod.
-- `n::Integer`: size of resampled output data. Default: 100
-- `block_size::Integer`: block size to use. Defaults to the optimal block length using `opt_block_length()`
+- `n::Int64`: size of resampled output data. Default: 100
+- `block_size::Float64`: block size to use. Defaults to the optimal block length using `opt_block_length()`
 
 ## Examples
 ```julia
@@ -30,8 +30,8 @@ input2 = BootstrapInput{MovingBlock}(;kwargs...)
 """
 struct BootstrapInput{T<:TSBootMethod} <: DataGenInput
     input_data::Array{<:Real} # array of data to be resampled
-    n::Integer # desired size of resampled data
-    block_size::Float32 #desired average block size (will add more to this later)
+    n::Int64 # desired size of resampled data
+    block_size::Float64 #desired average block size (will add more to this later)
 
     # constructor for kwargs
     function BootstrapInput{T}(;

--- a/src/DataGeneration/bootstrap.jl
+++ b/src/DataGeneration/bootstrap.jl
@@ -70,14 +70,14 @@ end
 
 # outer constructor for just using input_data and the type
 BootstrapInput(
-    input_data::Array{<:Real},
-    bootstrap_method::Type{<:TSBootMethod};
+    input_data,
+    bootstrap_method;
     n = 100,
     block_size = opt_block_length(input_data, bootstrap_method),
 ) = BootstrapInput{bootstrap_method}(input_data, n, block_size)
 
 
-function makedata(param::BootstrapInput{Stationary}, nSimulation::Integer = 1)
+function makedata(param::BootstrapInput{Stationary}, nSimulation = 1)
     # check for block_size > 1 so geometric distro doesn't blow up
     param.block_size > 1 ? block_size = param.block_size : block_size = 1.01
     p = 1 / block_size
@@ -116,7 +116,7 @@ function makedata(param::BootstrapInput{Stationary}, nSimulation::Integer = 1)
     return data
 end
 
-function makedata(param::BootstrapInput{MovingBlock}, nSimulation::Integer = 1)
+function makedata(param::BootstrapInput{MovingBlock}, nSimulation = 1)
     data = zeros((param.n, nSimulation))
     for run_num = 1:nSimulation
         block_counter = 0
@@ -136,7 +136,7 @@ function makedata(param::BootstrapInput{MovingBlock}, nSimulation::Integer = 1)
     return data
 end
 
-function makedata(param::BootstrapInput{CircularBlock}, nSimulation::Integer = 1)
+function makedata(param::BootstrapInput{CircularBlock}, nSimulation = 1)
     data = zeros((param.n, nSimulation))
     for run_num = 1:nSimulation
         block_counter = 0
@@ -199,7 +199,7 @@ st_bl = opt_block_length(ar1, Stationary)
 cb_bl = opt_block_length(ar1, CircularBlock)
 ```
 """
-function opt_block_length(array, bootstrap_method::Type{<:TSBootMethod})
+function opt_block_length(array, bootstrap_method)
     N = size(array)[1]
     K_N = max(5, floor(Int, sqrt(log10(N))))
     # m_max from Kevin Sheppard arch package and Andrew Patton Matlab code

--- a/src/DataGeneration/factory.jl
+++ b/src/DataGeneration/factory.jl
@@ -19,7 +19,7 @@ widget = Stock(prices)
 list_of_widgets = factory(widget, Stationary, 2)
 ```
 """
-function factory(widget::Widget, bootstrap_method::Type{<:TSBootMethod}, nWidgets::Signed)
+function factory(widget::Widget, bootstrap_method, nWidgets)
     fields = field_exclude(widget)
     # calculating the returns
     # TODO: check if time series Stationary 
@@ -52,8 +52,8 @@ end
 
 function factory(
     fin_instrument::FinancialInstrument,
-    bootstrap_method::Type{<:TSBootMethod},
-    nInstruments::Signed,
+    bootstrap_method,
+    nInstruments,
 )
     fields = field_exclude(fin_instrument)
     widget_ar = factory(fin_instrument.widget, bootstrap_method, nInstruments)

--- a/src/DataGeneration/logdiffusion.jl
+++ b/src/DataGeneration/logdiffusion.jl
@@ -22,10 +22,10 @@ then shifted and scaled by the drift and volatility terms.
 
 ## Arguments
 
-- `nTimeStep::Integer`:  The number of time steps to synthesize.
-- `initial::Real`:  The assumed value at the 0th time step. Default: 100.
-- `volatility::Real`:  The price volatility as a standard deviation in terms of implied time period. Defaults to 0.3.
-- `drift::Real`: The drift parameter describes the mean of the log-normal diffusion process 
+- `nTimeStep::Int64`:  The number of time steps to synthesize.
+- `initial::Float64`:  The assumed value at the 0th time step. Default: 100.
+- `volatility::Float64`:  The price volatility as a standard deviation in terms of implied time period. Defaults to 0.3.
+- `drift::Float64`: The drift parameter describes the mean of the log-normal diffusion process 
 given in terms of the entire implied time period (if simulating a year, drift would be annual 
 expected return). Defaults to 0.02.
 
@@ -42,10 +42,10 @@ input3 = LogDiffInput(;kwargs...)
 ```
 """
 struct LogDiffInput <: DataGenInput
-    nTimeStep::Integer # number of timesteps to simulate
-    initial::Real # in dollars
-    volatility::Real # volatility as a standard deviation
-    drift::Real # 
+    nTimeStep::Int64 # number of timesteps to simulate
+    initial::Float64 # in dollars
+    volatility::Float64 # volatility as a standard deviation
+    drift::Float64 # 
     # constructor for kwargs
     function LogDiffInput(;
         nTimeStep,

--- a/src/DataGeneration/logdiffusion.jl
+++ b/src/DataGeneration/logdiffusion.jl
@@ -65,11 +65,11 @@ struct LogDiffInput <: DataGenInput
     end
 end
 # outer constructor for passing just nTimeStep
-LogDiffInput(nTimeStep::Int; initial = 100, volatility = 0.3, drift = 0.02) =
+LogDiffInput(nTimeStep; initial = 100, volatility = 0.3, drift = 0.02) =
     LogDiffInput(nTimeStep, initial, volatility, drift)
 
 
-function makedata(Input::LogDiffInput, nSimulation::Integer = 1)
+function makedata(Input::LogDiffInput, nSimulation = 1)
 
     # compute array of random values
     nData = Input.nTimeStep + 1

--- a/src/Instruments/financial_instruments.jl
+++ b/src/Instruments/financial_instruments.jl
@@ -104,8 +104,8 @@ EuroCallOption(;kwargs...)
 ```
 """
 EuroCallOption(
-    widget::Widget,
-    strike_price::Real = widget.prices[end];
+    widget,
+    strike_price = widget.prices[end];
     maturity = 1,
     risk_free_rate = 0.02,
     label = "",
@@ -120,11 +120,11 @@ EuroCallOption(
 )
 
 EuroCallOption(
-    widget::Widget,
-    strike_price::Real,
-    maturity::Real,
-    label::String,
-    values_library::Dict{String,Dict{String,Float64}},
+    widget,
+    strike_price,
+    maturity,
+    label,
+    values_library,
 ) = EuroCallOption{typeof(widget)}(;
     widget = widget,
     strik_price = strike_price,
@@ -159,7 +159,6 @@ struct AmericanCallOption{T<:Widget} <: CallOption{T}
     strike_price::Float64
     maturity::Float64
     risk_free_rate::Float64
-
     label::String
     values_library::Dict{String,Dict{String,Float64}}
 
@@ -226,8 +225,8 @@ AmericanCallOption(;kwargs...)
 ```
 """
 AmericanCallOption(
-    widget::Widget,
-    strike_price::Real = widget.prices[end];
+    widget,
+    strike_price = widget.prices[end];
     maturity = 1,
     risk_free_rate = 0.02,
     label = "",
@@ -242,12 +241,12 @@ AmericanCallOption(
 )
 
 AmericanCallOption(
-    widget::Widget,
-    strike_price::Real,
-    maturity::Real,
-    risk_free_rate::Real,
-    label::String,
-    values_library::Dict{String,Dict{String,Float64}},
+    widget,
+    strike_price,
+    maturity,
+    risk_free_rate,
+    label,
+    values_library,
 ) = AmericanCallOption{typeof(widget)}(;
     widget = widget,
     strik_price = strike_price,
@@ -282,7 +281,6 @@ struct EuroPutOption{T<:Widget} <: PutOption{T}
     strike_price::Float64
     maturity::Float64
     risk_free_rate::Float64
-
     label::String
     values_library::Dict{String,Dict{String,Float64}}
 
@@ -351,8 +349,8 @@ EuroPutOption(;kwargs...)
 ```
 """
 EuroPutOption(
-    widget::Widget,
-    strike_price::Real = widget.prices[end];
+    widget,
+    strike_price = widget.prices[end];
     maturity = 1,
     risk_free_rate = 0.02,
     label = "",
@@ -367,12 +365,12 @@ EuroPutOption(
 )
 
 EuroPutOption(
-    widget::Widget,
-    strike_price::Real,
-    maturity::Real,
-    risk_free_rate::Real,
-    label::String,
-    values_library::Dict{String,Dict{String,Float64}},
+    widget,
+    strike_price,
+    maturity,
+    risk_free_rate,
+    label,
+    values_library,
 ) = EuroPutOption{typeof(widget)}(;
     widget = widget,
     strik_price = strike_price,
@@ -408,7 +406,6 @@ struct AmericanPutOption{T<:Widget} <: PutOption{T}
     strike_price::Float64
     maturity::Float64
     risk_free_rate::Float64
-
     label::String
     values_library::Dict{String,Dict{String,Float64}}
 
@@ -479,8 +476,8 @@ AmericanPutOption(;kwargs...)
 ```
 """
 AmericanPutOption(
-    widget::Widget,
-    strike_price::Real = widget.prices[end];
+    widget,
+    strike_price = widget.prices[end];
     maturity = 1,
     risk_free_rate = 0.02,
     label = "",
@@ -495,11 +492,11 @@ AmericanPutOption(
 )
 
 AmericanPutOption(
-    widget::Widget,
-    strike_price::Real,
-    maturity::Real,
-    risk_free_rate::Real,
-    values_library::Dict{String,Dict{String,Float64}},
+    widget,
+    strike_price,
+    maturity,
+    risk_free_rate,
+    values_library,
 ) = AmericanPutOption{typeof(widget)}(;
     widget = widget,
     strik_price = strike_price,
@@ -549,7 +546,7 @@ struct ETF <: FinancialInstrument end
 struct InterestRateSwap <: FinancialInstrument end
 
 #------- Helpers
-function add_price_value(a_fin_inst::FinancialInstrument, a_new_price::Real)
+function add_price_value(a_fin_inst::FinancialInstrument, a_new_price)
     a_new_price >= 0 ? nothing :
     @warn("You are trying to add a negative number to a prices list")
     push!(a_fin_inst.widget.prices, a_new_price)

--- a/src/Instruments/financial_instruments.jl
+++ b/src/Instruments/financial_instruments.jl
@@ -34,12 +34,11 @@ European call option with underlying asset `T`.
 """
 struct EuroCallOption{T<:Widget} <: CallOption{T}
     widget::T
-    strike_price::AbstractFloat
-    maturity::AbstractFloat
-    risk_free_rate::AbstractFloat
-
+    strike_price::Float64
+    maturity::Float64
+    risk_free_rate::Float64
     label::String
-    values_library::Dict{String,Dict{String,AbstractFloat}}
+    values_library::Dict{String,Dict{String,Float64}}
 
     # kwargs constructor
     function EuroCallOption{T}(;
@@ -48,11 +47,11 @@ struct EuroCallOption{T<:Widget} <: CallOption{T}
         maturity = 1,
         risk_free_rate = 0.02,
         label = "",
-        values_library = Dict{String,Dict{String,AbstractFloat}}(),
+        values_library = Dict{String,Dict{String,Float64}}(),
     ) where {T<:Widget}
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive ", maturity)
-        values_library == Dict{String,Dict{String,AbstractFloat}}() ? nothing :
+        values_library == Dict{String,Dict{String,Float64}}() ? nothing :
         @warn("It is not recommended to pass values through the constructor. \
         price!(Instrument, pricing_model) should be used")
         new{T}(widget, strike_price, maturity, risk_free_rate, label, values_library)
@@ -69,7 +68,7 @@ struct EuroCallOption{T<:Widget} <: CallOption{T}
     ) where {T<:Widget}
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive")
-        values_library == Dict{String,Dict{String,AbstractFloat}}() ? nothing :
+        values_library == Dict{String,Dict{String,Float64}}() ? nothing :
         @warn("It is not recommended to pass values through the constructor. \
         price!(Instrument, pricing_model) should be used")
 
@@ -110,7 +109,7 @@ EuroCallOption(
     maturity = 1,
     risk_free_rate = 0.02,
     label = "",
-    values_library = Dict{String,Dict{String,AbstractFloat}}(),
+    values_library = Dict{String,Dict{String,Float64}}(),
 ) = EuroCallOption{typeof(widget)}(;
     widget = widget,
     strike_price = strike_price,
@@ -125,7 +124,7 @@ EuroCallOption(
     strike_price::Real,
     maturity::Real,
     label::String,
-    values_library::Dict{String,Dict{String,AbstractFloat}},
+    values_library::Dict{String,Dict{String,Float64}},
 ) = EuroCallOption{typeof(widget)}(;
     widget = widget,
     strik_price = strike_price,
@@ -140,7 +139,7 @@ EuroCallOption(;
     maturity = 1,
     risk_free_rate = 0.02,
     label = "",
-    values_library = Dict{String,Dict{String,AbstractFloat}}(),
+    values_library = Dict{String,Dict{String,Float64}}(),
 ) = EuroCallOption{typeof(widget)}(;
     widget = widget,
     strike_price = strike_price,
@@ -157,12 +156,12 @@ American call option with underlying asset `T`.
 """
 struct AmericanCallOption{T<:Widget} <: CallOption{T}
     widget::T
-    strike_price::AbstractFloat
-    maturity::AbstractFloat
-    risk_free_rate::AbstractFloat
+    strike_price::Float64
+    maturity::Float64
+    risk_free_rate::Float64
 
     label::String
-    values_library::Dict{String,Dict{String,AbstractFloat}}
+    values_library::Dict{String,Dict{String,Float64}}
 
     # kwargs constructor
     function AmericanCallOption{T}(;
@@ -171,11 +170,11 @@ struct AmericanCallOption{T<:Widget} <: CallOption{T}
         maturity = 1,
         risk_free_rate = 0.02,
         label = "",
-        values_library = Dict{String,Dict{String,AbstractFloat}}(),
+        values_library = Dict{String,Dict{String,Float64}}(),
     ) where {T<:Widget}
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive")
-        values_library == Dict{String,Dict{String,AbstractFloat}}() ? nothing :
+        values_library == Dict{String,Dict{String,Float64}}() ? nothing :
         @warn("It is not recommended to pass values through the constructor. \
         price!(Instrument, pricing_model) should be used")
         new{T}(widget, strike_price, maturity, risk_free_rate, label, values_library)
@@ -192,7 +191,7 @@ struct AmericanCallOption{T<:Widget} <: CallOption{T}
     ) where {T<:Widget}
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive")
-        values_library == Dict{String,Dict{String,AbstractFloat}}() ? nothing :
+        values_library == Dict{String,Dict{String,Float64}}() ? nothing :
         @warn("It is not recommended to pass values through the constructor. \
         price!(Instrument, pricing_model) should be used")
         new{T}(widget, strike_price, maturity, risk_free_rate, label, values_library)
@@ -232,7 +231,7 @@ AmericanCallOption(
     maturity = 1,
     risk_free_rate = 0.02,
     label = "",
-    values_library = Dict{String,Dict{String,AbstractFloat}}(),
+    values_library = Dict{String,Dict{String,Float64}}(),
 ) = AmericanCallOption{typeof(widget)}(;
     widget = widget,
     strike_price = strike_price,
@@ -248,7 +247,7 @@ AmericanCallOption(
     maturity::Real,
     risk_free_rate::Real,
     label::String,
-    values_library::Dict{String,Dict{String,AbstractFloat}},
+    values_library::Dict{String,Dict{String,Float64}},
 ) = AmericanCallOption{typeof(widget)}(;
     widget = widget,
     strik_price = strike_price,
@@ -264,7 +263,7 @@ AmericanCallOption(;
     maturity = 1,
     risk_free_rate = 0.02,
     label = "",
-    values_library = Dict{String,Dict{String,AbstractFloat}}(),
+    values_library = Dict{String,Dict{String,Float64}}(),
 ) = AmericanCallOption{typeof(widget)}(;
     widget = widget,
     strike_price = strike_price,
@@ -280,12 +279,12 @@ European put option with underlying asset `T`.
 """
 struct EuroPutOption{T<:Widget} <: PutOption{T}
     widget::T
-    strike_price::AbstractFloat
-    maturity::AbstractFloat
-    risk_free_rate::AbstractFloat
+    strike_price::Float64
+    maturity::Float64
+    risk_free_rate::Float64
 
     label::String
-    values_library::Dict{String,Dict{String,AbstractFloat}}
+    values_library::Dict{String,Dict{String,Float64}}
 
     # kwargs constructor
     function EuroPutOption{T}(;
@@ -294,11 +293,11 @@ struct EuroPutOption{T<:Widget} <: PutOption{T}
         maturity = 1,
         risk_free_rate = 0.02,
         label = "",
-        values_library = Dict{String,Dict{String,AbstractFloat}}(),
+        values_library = Dict{String,Dict{String,Float64}}(),
     ) where {T<:Widget}
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive")
-        values_library == Dict{String,Dict{String,AbstractFloat}}() ? nothing :
+        values_library == Dict{String,Dict{String,Float64}}() ? nothing :
         @warn("It is not recommended to pass values through the constructor. \
         price!(Instrument, pricing_model) should be used")
 
@@ -316,7 +315,7 @@ struct EuroPutOption{T<:Widget} <: PutOption{T}
     ) where {T<:Widget}
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive")
-        values_library == Dict{String,Dict{String,AbstractFloat}}() ? nothing :
+        values_library == Dict{String,Dict{String,Float64}}() ? nothing :
         @warn("It is not recommended to pass values through the constructor. \
         price!(Instrument, pricing_model) should be used")
 
@@ -357,7 +356,7 @@ EuroPutOption(
     maturity = 1,
     risk_free_rate = 0.02,
     label = "",
-    values_library = Dict{String,Dict{String,AbstractFloat}}(),
+    values_library = Dict{String,Dict{String,Float64}}(),
 ) = EuroPutOption{typeof(widget)}(;
     widget = widget,
     strike_price = strike_price,
@@ -373,7 +372,7 @@ EuroPutOption(
     maturity::Real,
     risk_free_rate::Real,
     label::String,
-    values_library::Dict{String,Dict{String,AbstractFloat}},
+    values_library::Dict{String,Dict{String,Float64}},
 ) = EuroPutOption{typeof(widget)}(;
     widget = widget,
     strik_price = strike_price,
@@ -389,7 +388,7 @@ EuroPutOption(;
     maturity = 1,
     risk_free_rate = 0.02,
     label = "",
-    values_library = Dict{String,Dict{String,AbstractFloat}}(),
+    values_library = Dict{String,Dict{String,Float64}}(),
 ) = EuroPutOption{typeof(widget)}(;
     widget = widget,
     strike_price = strike_price,
@@ -406,12 +405,12 @@ American put option with underlying asset `T`.
 """
 struct AmericanPutOption{T<:Widget} <: PutOption{T}
     widget::T
-    strike_price::AbstractFloat
-    maturity::AbstractFloat
-    risk_free_rate::AbstractFloat
+    strike_price::Float64
+    maturity::Float64
+    risk_free_rate::Float64
 
     label::String
-    values_library::Dict{String,Dict{String,AbstractFloat}}
+    values_library::Dict{String,Dict{String,Float64}}
 
     # kwargs constructor
     function AmericanPutOption{T}(;
@@ -420,12 +419,12 @@ struct AmericanPutOption{T<:Widget} <: PutOption{T}
         maturity = 1,
         risk_free_rate = 0.02,
         label = "",
-        values_library = Dict{String,Dict{String,AbstractFloat}}(),
+        values_library = Dict{String,Dict{String,Float64}}(),
     ) where {T<:Widget}
 
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive")
-        values_library == Dict{String,Dict{String,AbstractFloat}}() ? nothing :
+        values_library == Dict{String,Dict{String,Float64}}() ? nothing :
         @warn("It is not recommended to pass values through the constructor. \
         price!(Instrument, pricing_model) should be used")
 
@@ -444,7 +443,7 @@ struct AmericanPutOption{T<:Widget} <: PutOption{T}
 
         strike_price >= 0 ? nothing : error("strike_price must be non-negative")
         maturity >= 0 ? nothing : error("maturity must be positive")
-        values_library == Dict{String,Dict{String,AbstractFloat}}() ? nothing :
+        values_library == Dict{String,Dict{String,Float64}}() ? nothing :
         @warn("It is not recommended to pass values through the constructor. \
         price!(Instrument, pricing_model) should be used")
 
@@ -485,7 +484,7 @@ AmericanPutOption(
     maturity = 1,
     risk_free_rate = 0.02,
     label = "",
-    values_library = Dict{String,Dict{String,AbstractFloat}}(),
+    values_library = Dict{String,Dict{String,Float64}}(),
 ) = AmericanPutOption{typeof(widget)}(;
     widget = widget,
     strike_price = strike_price,
@@ -500,7 +499,7 @@ AmericanPutOption(
     strike_price::Real,
     maturity::Real,
     risk_free_rate::Real,
-    values_library::Dict{String,Dict{String,AbstractFloat}},
+    values_library::Dict{String,Dict{String,Float64}},
 ) = AmericanPutOption{typeof(widget)}(;
     widget = widget,
     strik_price = strike_price,
@@ -516,7 +515,7 @@ AmericanPutOption(;
     maturity = 1,
     risk_free_rate = 0.02,
     label = "",
-    values_library = Dict{String,Dict{String,AbstractFloat}}(),
+    values_library = Dict{String,Dict{String,Float64}}(),
 ) = AmericanPutOption{typeof(widget)}(;
     widget = widget,
     strike_price = strike_price,
@@ -536,11 +535,11 @@ Future contract with underlying asset 'T'.
 """
 struct Future{T<:Widget} <: FinancialInstrument
     widget::T
-    strike_price::AbstractFloat
-    risk_free_rate::AbstractFloat
-    maturity::AbstractFloat
+    strike_price::Float64
+    risk_free_rate::Float64
+    maturity::Float64
     label::String
-    values_library::Dict{String,Dict{String,AbstractFloat}}
+    values_library::Dict{String,Dict{String,Float64}}
 end
 
 # ------ Type system for stuff we haven't figured out yet ------ 

--- a/src/Instruments/widgets.jl
+++ b/src/Instruments/widgets.jl
@@ -111,7 +111,7 @@ Stock(;kwargs...)
 Stock(40; volatility=.05)
 ```
 """
-function Stock(price::Real; name = "", volatility)
+function Stock(price::Number; name = "", volatility)
     prices = [price]
     Stock{typeof(price)}(; prices = prices, name = name, volatility = volatility, timesteps_per_period = 0)
 end
@@ -234,7 +234,7 @@ Commodity(;kwargs...)
 Commodity(40; volatility=.05)
 ```
 """
-function Commodity(price::Real; name = "", volatility)
+function Commodity(price::Number; name = "", volatility)
     prices = [price]
     Commodity{typeof(price)}(;
         prices = prices,
@@ -309,7 +309,7 @@ Bond(;kwargs...)
 Bond(2; coupon_rate=.05)
 ```
 """
-function Bond(price::Real; name = "", time_mat = 1, coupon_rate = 0.03)
+function Bond(price::Number; name = "", time_mat = 1, coupon_rate = 0.03)
     prices = [price]
     Bond{typeof(price)}(; prices = prices, name = name, time_mat = time_mat, coupon_rate = coupon_rate)
 end
@@ -338,7 +338,7 @@ end
 
 get_volatility(prices) = get_volatility(prices, length(prices))
 
-function add_price_value(a_widget::Widget, a_new_price::Real)
+function add_price_value(a_widget::Widget, a_new_price)
     a_new_price >= 0 ? nothing :
     @warn("You are trying to add a negative number to a prices list")
     push!(a_widget.prices, a_new_price)

--- a/src/Models/pricingmodels.jl
+++ b/src/Models/pricingmodels.jl
@@ -56,14 +56,6 @@ function price!(
     delta = 0,
     _...
 )
-    """ 
-    EURO OPTION
-    tree_depth = the depth of the tree
-    r = rate of return
-    strike_price = the strike price in dollars
-    delta = intrest rate
-    """
-
     r = fin_obj.risk_free_rate
     strike_price = fin_obj.strike_price
     s_0 = last(fin_obj.widget.prices)

--- a/src/Models/pricingmodels.jl
+++ b/src/Models/pricingmodels.jl
@@ -24,7 +24,7 @@ price!(a_fin_inst, BinomialTree)
 ```
 """
 price!(fin_obj, pricing_model; _...) = 
-    error("Cannon price $(typeof(fin_obj)) with $(typeof(pricing_model))")
+    error("Cannot price $(typeof(fin_obj)) with $(typeof(pricing_model))")
 
 """
     price!(fin_obj::Option, pricing_model::Type{BinomialTree}; kwargs...)

--- a/src/Models/pricingmodels.jl
+++ b/src/Models/pricingmodels.jl
@@ -23,8 +23,9 @@ a_fin_inst = EuroCallOption(a_stock, 40; risk_free_rate=.05)
 price!(a_fin_inst, BinomialTree)  
 ```
 """
-price!(fin_obj::Any, pricing_model::Type{<:Any}; _...) =
-    error("Use a FinancialObject and a Model type")
+price!(fin_obj, pricing_model; _...) = 
+    error("Cannon price $(typeof(fin_obj)) with $(typeof(pricing_model))")
+
 """
     price!(fin_obj::Option, pricing_model::Type{BinomialTree}; kwargs...)
 
@@ -47,8 +48,6 @@ a_fin_inst = EuroCallOption(a_stock, 40; risk_free_rate=.05)
 price!(a_fin_inst, BinomialTree)  
 ```
 """
-price!(fin_obj::Option, pricing_model::Type{BinomialTree}; _...) =
-    error("Something went wrong. Make sure you're using a defined Option subtype")
 
 function price!(
     fin_obj::EuroCallOption,
@@ -251,8 +250,6 @@ call = EuroCallOption(stock, 40; risk_free_rate=.08, maturity=.25)
 price!(call, BlackScholes)
 ```
 """
-price!(fin_obj::Option, pricing_model::Type{BlackScholes}; _...) =
-    error("Use a European call or put option for the Black Scholes pricing method")
 
 function price!(fin_obj::EuroCallOption{<:Widget}, pricing_model::Type{BlackScholes}; _...)
     c1 = log(fin_obj.widget.prices[end] / fin_obj.strike_price)
@@ -294,28 +291,6 @@ end
 
 
 # ----- Price models using Monte Carlo sims
-
-# error out if using an American option 
-price!(
-    fin_obj::AmericanCallOption{<:Widget},
-    pricing_model::Type{MonteCarlo{LogDiffusion}};
-    _...,
-) = error("Cannot price an American Option using Monte Carlo methods now")
-price!(
-    fin_obj::AmericanPutOption{<:Widget},
-    pricing_model::Type{MonteCarlo{LogDiffusion}};
-    _...,
-) = error("Cannot price an American Option using Monte Carlo methods now")
-price!(
-    fin_obj::AmericanCallOption{<:Widget},
-    pricing_model::Type{MonteCarlo{MCBootstrap}};
-    _...,
-) = error("Cannot price an American Option using Monte Carlo methods now")
-price!(
-    fin_obj::AmericanPutOption{<:Widget},
-    pricing_model::Type{MonteCarlo{MCBootstrap}};
-    _...,
-) = error("Cannot price an American Option using Monte Carlo methods now")
 """
     price!(fin_obj::Option, MonteCarlo{MonteCarloModel}; kwargs...)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ include("fininsttests.jl")
 
 include("datagentests.jl")
 include("bootstraptests.jl")
-include("factorytest.jl")
+#include("factorytest.jl")
 
 include("pricingmodeltests.jl")
 


### PR DESCRIPTION
Fixes #69. Took out unnecessary type annotations that were not being used specifically for dispatch. 